### PR TITLE
[FFM-2680]: Tests should generate user friendly testname

### DIFF
--- a/src/test/java/io/harness/cf/client/api/EvaluatorIntegrationTest.java
+++ b/src/test/java/io/harness/cf/client/api/EvaluatorIntegrationTest.java
@@ -18,6 +18,7 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.testng.Assert;
 import org.testng.annotations.Factory;
+import java.nio.file.Files;
 
 @Slf4j
 public class EvaluatorIntegrationTest {
@@ -96,7 +97,8 @@ public class EvaluatorIntegrationTest {
 
       for (final String key : file.getExpected().keySet()) {
         final Object expected = file.getExpected().get(key);
-        final TestCase testCase = new TestCase(file.getTestFile(), key, expected, file);
+        final String testName =  removeExtension(file.getTestFile());
+        final TestCase testCase = new TestCase(file.getTestFile(), key, expected, file, testName);
         final FFUseCaseTest useCase = new FFUseCaseTest(testCase, evaluator);
         Assert.assertTrue(list.add(useCase));
       }
@@ -115,4 +117,13 @@ public class EvaluatorIntegrationTest {
     }
     return builder.toString();
   }
+
+  public static String removeExtension(String fname) {
+    int pos = fname.lastIndexOf('.');
+    if(pos > -1)
+      return fname.substring(0, pos);
+    else
+      return fname;
+  }
 }
+

--- a/src/test/java/io/harness/cf/client/api/FFUseCaseTest.java
+++ b/src/test/java/io/harness/cf/client/api/FFUseCaseTest.java
@@ -5,17 +5,33 @@ import io.harness.cf.client.dto.Target;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.testng.Assert;
+import org.testng.ITest;
 import org.testng.annotations.Test;
+import org.testng.annotations.BeforeMethod;
+
+import java.lang.reflect.Method;
 
 @Slf4j
-public class FFUseCaseTest {
+public class FFUseCaseTest implements ITest {
 
   private final TestCase testCase;
   private final Evaluator evaluator;
 
+  private ThreadLocal<String> testName = new ThreadLocal<>();
+
   public FFUseCaseTest(@NonNull final TestCase testCase, @NonNull final Evaluator evaluator) {
     this.testCase = testCase;
     this.evaluator = evaluator;
+  }
+
+  @BeforeMethod
+  public void BeforeMethod(Method method, Object[] testData){
+    testName.set(testCase.getTestName());
+  }
+
+  @Override
+  public String getTestName() {
+    return testName.get();
   }
 
   @Test

--- a/src/test/java/io/harness/cf/client/api/FFUseCaseTest.java
+++ b/src/test/java/io/harness/cf/client/api/FFUseCaseTest.java
@@ -26,7 +26,7 @@ public class FFUseCaseTest implements ITest {
 
   @BeforeMethod
   public void BeforeMethod(Method method, Object[] testData){
-    testName.set(testCase.getTestName());
+    testName.set(testCase.getTestName() + "_with_target_" +testCase.getTargetIdentifier());
   }
 
   @Override

--- a/src/test/java/io/harness/cf/client/api/FFUseCaseTest.java
+++ b/src/test/java/io/harness/cf/client/api/FFUseCaseTest.java
@@ -17,7 +17,7 @@ public class FFUseCaseTest implements ITest {
   private final TestCase testCase;
   private final Evaluator evaluator;
 
-  private ThreadLocal<String> testName = new ThreadLocal<>();
+  private final ThreadLocal<String> testName = new ThreadLocal<>();
 
   public FFUseCaseTest(@NonNull final TestCase testCase, @NonNull final Evaluator evaluator) {
     this.testCase = testCase;

--- a/src/test/java/io/harness/cf/client/api/TestCase.java
+++ b/src/test/java/io/harness/cf/client/api/TestCase.java
@@ -10,4 +10,5 @@ public class TestCase {
   private final String targetIdentifier;
   private final Object expectedValue;
   private final TestFileData fileData;
+  private final String testName;
 }


### PR DESCRIPTION
Currently the evaluation tests output the test driver method name
i.e. 'runTestCase'

When adding new test cases it can be hard to see what test is actually running/failing.
This change introduces a test name.

After tests run the name should be inserted as the testcase name in the XML output i.e.

  <testcase name="test_empty_or_missing_target_attributes" classname="io.harness.cf.client.api.FFUseCaseTest" time="0.009">