### PR TITLE
[FFM-2680]: Fix NPE when checking attributes map

### DIFF
--- a/src/main/java/io/harness/cf/client/api/Evaluator.java
+++ b/src/main/java/io/harness/cf/client/api/Evaluator.java
@@ -30,20 +30,22 @@ class Evaluator implements Evaluation {
     this.query = query;
   }
 
-  protected Optional<Object> getAttrValue(Target target, @NonNull String attribute) {
+  protected Optional<Object> getAttrValue(@NonNull Target target, @NonNull String attribute) {
     if (Strings.isNullOrEmpty(attribute)) {
       log.debug("Attribute is empty");
       return Optional.empty();
     }
-    try {
-      Field field = Target.class.getDeclaredField(attribute);
-      field.setAccessible(true);
-      return Optional.of(field.get(target));
-    } catch (NoSuchFieldException | IllegalAccessException e) {
-      if (target.getAttributes() != null) {
-        log.debug("Checking attributes field {}", attribute);
-        return Optional.of(target.getAttributes().get(attribute));
-      }
+
+    switch(attribute) {
+      case "identifier":
+        return Optional.of(target.getIdentifier());
+      case "name":
+        return Optional.ofNullable(target.getName());
+      default:
+        if (target.getAttributes() != null) {
+          log.debug("Checking attributes field {}", attribute);
+          return Optional.ofNullable(target.getAttributes().get(attribute));
+        }
     }
     log.error("Attribute {} does not exist", attribute);
     return Optional.empty();

--- a/src/main/java/io/harness/cf/client/api/Evaluator.java
+++ b/src/main/java/io/harness/cf/client/api/Evaluator.java
@@ -30,9 +30,14 @@ class Evaluator implements Evaluation {
     this.query = query;
   }
 
-  protected Optional<Object> getAttrValue(@NonNull Target target, @NonNull String attribute) {
+  protected Optional<Object> getAttrValue(Target target, @NonNull String attribute) {
     if (Strings.isNullOrEmpty(attribute)) {
       log.debug("Attribute is empty");
+      return Optional.empty();
+    }
+
+    if (target == null) {
+      log.debug("Target is null");
       return Optional.empty();
     }
 


### PR DESCRIPTION
 ### What
This change uses the Optional.ofNullable, which handles the null and
returns empty.

This change also removes the reflection when used to lookup the name
and identifier fields of a target.

### Why
When attempting to access an attribute in a map, which does not exist
 a null was being passed to the Optional.of function.
This caused a NPE.

### Testing
A evaluation test was added to simulate this case.