### PR TITLE
FFM-3694 Fix enableAnalytics

### DIFF
--- a/examples/src/main/java/io/harness/ff/examples/GettingStarted.java
+++ b/examples/src/main/java/io/harness/ff/examples/GettingStarted.java
@@ -19,16 +19,16 @@ public class GettingStarted {
     public static void main(String[] args) {
         System.out.println("Harness SDK Getting Started");
 
+        //Create a Feature Flag Client
+        CfClient cfClient = new CfClient(apiKey, Config.builder().build());
+
         try {
-            //Create a Feature Flag Client
-            CfClient cfClient = new CfClient(apiKey);
             cfClient.waitForInitialization();
 
             // Create a target (different targets can get different results based on rules.  This includes a custom attribute 'location')
             final Target target = Target.builder()
                     .identifier("javasdk")
                     .name("JavaSDK")
-                    .attribute("location", "emea")
                     .build();
 
             // Loop forever reporting the state of the flag
@@ -45,7 +45,7 @@ public class GettingStarted {
             e.printStackTrace();
         } finally {
             // Close the SDK
-            CfClient.getInstance().close();
+            cfClient.close();
         }
     }
 

--- a/src/main/java/io/harness/cf/client/api/InnerClient.java
+++ b/src/main/java/io/harness/cf/client/api/InnerClient.java
@@ -82,6 +82,7 @@ class InnerClient
       log.error("SDK key cannot be empty!");
       return;
     }
+
     HarnessConfig config = HarnessConfig.builder().build();
     HarnessConnector harnessConnector = new HarnessConnector(sdkKey, config);
     setUp(harnessConnector, options);
@@ -354,7 +355,9 @@ class InnerClient
   @Override
   public void processEvaluation(
       @NonNull FeatureConfig featureConfig, Target target, @NonNull Variation variation) {
-    metricsProcessor.pushToQueue(target, featureConfig, variation);
+    if (this.options.isAnalyticsEnabled()) {
+      metricsProcessor.pushToQueue(target, featureConfig, variation);
+    }
   }
 
   public void close() {


### PR DESCRIPTION
Added conditional to check for enableAnalytics in processEvaluation
function. Should now prevent from queueing metrics data when
analyticsEnabled is set to false.

Will add tests at a later time as discussed.