### PR TITLE
FFM 4399 Configurable targets

### DIFF
--- a/src/main/java/io/harness/cf/client/api/BaseConfig.java
+++ b/src/main/java/io/harness/cf/client/api/BaseConfig.java
@@ -21,6 +21,8 @@ public class BaseConfig {
   // configurations for Analytics
   @Builder.Default private final boolean analyticsEnabled = true;
 
+  @Builder.Default private final boolean globalTargetEnabled = true;
+
   @Builder.Default
   @Getter(AccessLevel.NONE)
   private final int frequency = 60; // unit: second

--- a/src/main/java/io/harness/cf/client/api/MetricsProcessor.java
+++ b/src/main/java/io/harness/cf/client/api/MetricsProcessor.java
@@ -52,6 +52,13 @@ class MetricsProcessor extends AbstractScheduledService {
       executor().submit(this::runOneIteration);
     }
 
+    log.debug(
+        "Flag: " + featureName + " Target: " + target.getIdentifier() + " Variation: " + variation);
+
+    if (config.isGlobalTargetEnabled()) {
+      target.setIdentifier(GLOBAL_TARGET);
+    }
+
     try {
       queue.put(new MetricEvent(featureName, target, variation));
     } catch (InterruptedException e) {
@@ -105,7 +112,8 @@ class MetricsProcessor extends AbstractScheduledService {
     for (Map.Entry<MetricEvent, Integer> entry : data.entrySet()) {
       Target target = entry.getKey().getTarget();
       addTargetData(metrics, target);
-      SummaryMetrics summaryMetrics = prepareSummaryMetricsKey(entry.getKey());
+      SummaryMetrics summaryMetrics =
+          prepareSummaryMetricsKey(entry.getKey(), target.getIdentifier());
       summaryMetricsData.put(summaryMetrics, entry.getValue());
     }
 
@@ -118,7 +126,7 @@ class MetricsProcessor extends AbstractScheduledService {
           Arrays.asList(
               new KeyValue(FEATURE_NAME_ATTRIBUTE, entry.getKey().getFeatureName()),
               new KeyValue(VARIATION_IDENTIFIER_ATTRIBUTE, entry.getKey().getVariationIdentifier()),
-              new KeyValue(TARGET_ATTRIBUTE, GLOBAL_TARGET),
+              new KeyValue(TARGET_ATTRIBUTE, entry.getKey().getTargetIdentifier()),
               new KeyValue(SDK_TYPE, SERVER),
               new KeyValue(SDK_LANGUAGE, "java"),
               new KeyValue(SDK_VERSION, jarVersion)));
@@ -129,11 +137,12 @@ class MetricsProcessor extends AbstractScheduledService {
     return metrics;
   }
 
-  private SummaryMetrics prepareSummaryMetricsKey(MetricEvent key) {
+  private SummaryMetrics prepareSummaryMetricsKey(MetricEvent key, String targetIdentifier) {
     return SummaryMetrics.builder()
         .featureName(key.getFeatureName())
         .variationIdentifier(key.getVariation().getIdentifier())
         .variationValue(key.getVariation().getValue())
+        .targetIdentifier(targetIdentifier)
         .build();
   }
 

--- a/src/main/java/io/harness/cf/client/api/SummaryMetrics.java
+++ b/src/main/java/io/harness/cf/client/api/SummaryMetrics.java
@@ -13,4 +13,5 @@ class SummaryMetrics {
   private String featureName;
   private String variationIdentifier;
   private String variationValue;
+  private String targetIdentifier;
 }


### PR DESCRIPTION
Previously we were just sending globalTarget name, but now it can be configured to send the actual target by using globalTargetEnabled. Defaults to true.