### PR TITLE
FFM-4849 - Thread leak in MetricsProcessor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.harness</groupId>
     <artifactId>ff-java-server-sdk</artifactId>
-    <version>1.1.5.2</version>
+    <version>1.1.6-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Harness Feature Flag Java Server SDK</name>
     <description>Harness Feature Flag Java Server SDK</description>

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -9,6 +9,7 @@
         </encoder>
     </appender>
     <logger name="io.harness.cf.client" level="DEBUG"/>
+    <logger name="io.harness.cf.client.api.MetricsProcessor" level="WARN"/>
     <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>


### PR DESCRIPTION
 ### What
 Pushing a lot of metric events to the MetricsProcessor can result in: java.lang.OutOfMemoryError: unable to create new native thread

 ### Why
 When the LinkedBlockingQueue fills up, a thread is triggered to drain the events. However the call to executor() which is part of AbstractScheduledService actually creates a new thread via newSingleThreadScheduledExecutor on each call. When lots of events are pushed this caused submit() to be called many times each creating new thread - eventually till the JVM runs out of native memory.

 ### Testing
 Added a new unit test to push 100k metrics on a metrics queue with a small size (10). This test fails without the fix applied.