### PR TITLE
FFM-4396 Change Metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.harness</groupId>
     <artifactId>ff-java-server-sdk</artifactId>
-    <version>1.1.6-SNAPSHOT</version>
+    <version>1.1.6</version>
     <packaging>jar</packaging>
     <name>Harness Feature Flag Java Server SDK</name>
     <description>Harness Feature Flag Java Server SDK</description>

--- a/src/main/java/io/harness/cf/client/api/BaseConfig.java
+++ b/src/main/java/io/harness/cf/client/api/BaseConfig.java
@@ -27,7 +27,7 @@ public class BaseConfig {
   @Getter(AccessLevel.NONE)
   private final int frequency = 60; // unit: second
 
-  @Builder.Default private final int bufferSize = 1024;
+  @Builder.Default private final int bufferSize = 2048;
 
   // Flag to set all attributes as private
   @Builder.Default private final boolean allAttributesPrivate = false;

--- a/src/main/java/io/harness/cf/client/api/MetricEvent.java
+++ b/src/main/java/io/harness/cf/client/api/MetricEvent.java
@@ -2,6 +2,7 @@ package io.harness.cf.client.api;
 
 import io.harness.cf.client.dto.Target;
 import io.harness.cf.model.Variation;
+import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -13,4 +14,19 @@ class MetricEvent {
   private String featureName;
   private Target target;
   private Variation variation;
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    MetricEvent that = (MetricEvent) o;
+    return featureName.equals(that.featureName)
+        && target.equals(that.target)
+        && variation.equals(that.variation);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(featureName, target, variation);
+  }
 }

--- a/src/test/java/io/harness/cf/client/api/MetricsProcessorTest.java
+++ b/src/test/java/io/harness/cf/client/api/MetricsProcessorTest.java
@@ -1,6 +1,7 @@
 package io.harness.cf.client.api;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.collect.Maps;
 import io.harness.cf.client.connector.Connector;
@@ -16,9 +17,7 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
+import org.mockito.*;
 
 @Slf4j
 public class MetricsProcessorTest implements MetricsCallback {

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -9,7 +9,7 @@
         </encoder>
     </appender>
     <logger name="io.harness.cf.client" level="DEBUG"/>
-    <logger name="io.harness.cf.client.api.MetricsProcessor" level="WARN"/>
+    <logger name="io.harness.cf.client.api.MetricsProcessor" level="INFO"/>
     <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>


### PR DESCRIPTION
This PR changes the way we store the metrics and reduces memory as the previous method was storing too much and/or redundant data which caused the metrics processor potential out of memory errors. 
The changes are as follows:
- Changed from blocked queue to AtomicLongMap;
- Also includes various other cleanups and changes
- Updated unit test to test more permutations, added synchronized to runOneIteration()
