### PR TITLE
Improve coverage of Java SDK classes. Also change testng to JUnit5 to…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,16 +173,16 @@
         </dependency>
 
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-            <version>6.8</version>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>4.8.1</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-testng</artifactId>
-            <version>0.2.10</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.9.1</version>
             <scope>test</scope>
         </dependency>
 
@@ -272,7 +272,7 @@
                         </goals>
                         <configuration>
                             <sources>
-                                <source>target/generated-sources/packages</source>
+                                <source>target/generated-sources</source>
                             </sources>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -272,7 +272,7 @@
                         </goals>
                         <configuration>
                             <sources>
-                                <source>target/generated-sources</source>
+                                <source>target/generated-sources/openapi</source>
                             </sources>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.20</version>
+            <version>1.18.24</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/test/java/io/harness/cf/client/api/EvaluatorTest.java
+++ b/src/test/java/io/harness/cf/client/api/EvaluatorTest.java
@@ -1,21 +1,181 @@
 package io.harness.cf.client.api;
 
-import static org.testng.Assert.*;
+import static io.harness.cf.client.api.Operators.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import com.google.gson.reflect.TypeToken;
+import io.harness.cf.JSON;
 import io.harness.cf.client.dto.Target;
-import io.harness.cf.model.Clause;
-import io.harness.cf.model.Serve;
-import io.harness.cf.model.ServingRule;
-import java.util.ArrayList;
-import java.util.ConcurrentModificationException;
-import java.util.List;
-import java.util.Random;
+import io.harness.cf.model.*;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.*;
 import java.util.concurrent.*;
 import lombok.extern.slf4j.Slf4j;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
 @Slf4j
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class EvaluatorTest {
+
+  private Evaluator evaluator;
+  private List<FeatureConfig> features;
+
+  @BeforeAll
+  public void setupUp() throws IOException, URISyntaxException {
+    final StorageRepository repository = new StorageRepository(new CaffeineCache(100), null, null);
+    evaluator = new Evaluator(repository);
+
+    loadSegments(repository);
+
+    final String featuresJson =
+        getJsonResource("local-test-cases/percentage-rollout-with-zero-weights.json");
+    features =
+        new JSON().deserialize(featuresJson, new TypeToken<List<FeatureConfig>>() {}.getType());
+    assertFalse(features.isEmpty());
+  }
+
+  @Test
+  public void testPercentageRollout() throws URISyntaxException, IOException {
+
+    // JSON has a weight distribution of 25%, 50%, 25%, 0%
+
+    testPercentageRolloutMatches("andrew.bell@harness.io", "variationB"); // 31
+    testPercentageRolloutMatches("nobody1@harness.io", "variationA"); // 19
+    testPercentageRolloutMatches("nobody2@harness.io", "variationB"); // 36
+    testPercentageRolloutMatches("nobody3@harness.io", "variationA"); // 12
+    testPercentageRolloutMatches("nobody4@harness.io", "variationC"); // 87
+  }
+
+  private void testPercentageRolloutMatches(String targetIdentifier, String expectedVariant)
+      throws URISyntaxException, IOException {
+
+    final Target target =
+        Target.builder().identifier(targetIdentifier).name(targetIdentifier).build();
+    final Optional<String> actualVariant =
+        evaluator.evaluateRules(features.get(0).getRules(), target);
+
+    assertTrue(actualVariant.isPresent());
+    assertEquals(expectedVariant, actualVariant.get());
+  }
+
+  @Test
+  public void testPercentageRolloutDoesNotReturnZeroVariants()
+      throws URISyntaxException, IOException {
+
+    // JSON has a weight distribution of 25%, 50%, 25%, 0%
+    // Create enough of a distribution spread to hit has many email hashes as we can
+
+    final int RANDOM_EMAIL_COUNT = 1000;
+    final Random random = new Random();
+
+    for (int i = 0; i < RANDOM_EMAIL_COUNT; i++) {
+      final String nextEmail = String.format("%d@harness.io", random.nextInt());
+
+      final Target target = Target.builder().identifier(nextEmail).name(nextEmail).build();
+      final Optional<String> actualVariant =
+          evaluator.evaluateRules(features.get(0).getRules(), target);
+
+      assertTrue(actualVariant.isPresent());
+      assertNotEquals(
+          "variationD", actualVariant.get()); // variantD is 0% and should never be returned
+    }
+  }
+
+  @Test
+  public void shouldReturnFalseWhenClauseEmptyOrInvalid() {
+    final Target target =
+        Target.builder()
+            .identifier("andrew.bell@harness.io")
+            .name("andrew.bell@harness.io")
+            .build();
+    assertFalse(evaluator.evaluateClause(null, target));
+
+    Clause mockClause = mock(Clause.class);
+
+    when(mockClause.getOp()).thenReturn("");
+    assertFalse(evaluator.evaluateClause(mockClause, target));
+
+    when(mockClause.getOp()).thenReturn("notempty");
+    when(mockClause.getValues()).thenReturn(Collections.emptyList());
+    assertFalse(evaluator.evaluateClause(mockClause, target));
+
+    when(mockClause.getOp()).thenReturn("notempty");
+    when(mockClause.getValues()).thenReturn(Arrays.asList("@harness.io"));
+    when(mockClause.getAttribute()).thenReturn("idontexist");
+    assertFalse(evaluator.evaluateClause(mockClause, target));
+  }
+
+  @Test
+  public void shouldEvaluateOperatorClauseCorrectly() {
+    evaluateOperatorClause("andrew.bell@harness.io", STARTS_WITH, "andrew");
+    evaluateOperatorClause("andrew.bell@harness.io", ENDS_WITH, ".io");
+    evaluateOperatorClause("andrew.bell@harness.io", MATCH, ".*harness.*");
+    evaluateOperatorClause("andrew.bell@harness.io", CONTAINS, "bell");
+    evaluateOperatorClause("andrew.bell@harness.io", EQUAL, "Andrew.Bell@Harness.IO");
+    evaluateOperatorClause("andrew.bell@harness.io", EQUAL_SENSITIVE, "andrew.bell@harness.io");
+    evaluateOperatorClause("andrew", IN, "andrew,bell,harness,io");
+  }
+
+  @Test
+  public void shouldReturnFalseIfOperatorNotKnown() {
+    final Target target = Target.builder().identifier("dummy").name("dummy").build();
+
+    Clause mockClause = mock(Clause.class);
+    when(mockClause.getOp()).thenReturn("invalid-op");
+    when(mockClause.getAttribute()).thenReturn("identifier");
+    when(mockClause.getValues()).thenReturn(Arrays.asList("dummy"));
+    assertFalse(evaluator.evaluateClause(mockClause, target));
+  }
+
+  private void evaluateOperatorClause(String operand, String op, String expected) {
+    final Target target = Target.builder().identifier(operand).name(operand).build();
+
+    List<String> expectedList =
+        op.equals(IN) ? Arrays.asList(expected.split(",")) : Arrays.asList(expected);
+
+    Clause mockClause = mock(Clause.class);
+    when(mockClause.getOp()).thenReturn(op);
+    when(mockClause.getAttribute()).thenReturn("identifier");
+    when(mockClause.getValues()).thenReturn(expectedList);
+    assertTrue(evaluator.evaluateClause(mockClause, target));
+
+    when(mockClause.getAttribute()).thenReturn("name");
+    when(mockClause.getValues()).thenReturn(expectedList);
+    assertTrue(evaluator.evaluateClause(mockClause, target));
+  }
+
+  @Test
+  public void shouldReturnFalseWhenGetAttrValueEmptyOrInvalid() {
+    Target target =
+        Target.builder()
+            .identifier("andrew.bell@harness.io")
+            .name("andrew.bell@harness.io")
+            .build();
+
+    assertFalse(evaluator.getAttrValue(target, "").isPresent());
+    assertFalse(evaluator.getAttrValue(null, "notempty").isPresent());
+    assertFalse(evaluator.getAttrValue(target, "idontexist").isPresent());
+
+    target = mock(Target.class);
+    when(target.getAttributes()).thenReturn(null);
+    assertFalse(evaluator.getAttrValue(target, "idontexist").isPresent());
+  }
+
+  @Test
+  public void shouldReturnCorrectAttrForGetAttrValue() {
+    Target target = Target.builder().identifier("andrew.bell@harness.io").name("andrew").build();
+
+    assertEquals("andrew.bell@harness.io", evaluator.getAttrValue(target, "identifier").get());
+    assertEquals("andrew", evaluator.getAttrValue(target, "name").get());
+  }
 
   @Test
   public void testEvaluateRules() throws InterruptedException {
@@ -70,6 +230,21 @@ public class EvaluatorTest {
     latch.await();
     for (final Exception e : failures) {
       fail("Failure", e);
+    }
+  }
+
+  private String getJsonResource(String location) throws IOException, URISyntaxException {
+    Path path = Paths.get(EvaluatorTest.class.getClassLoader().getResource(location).toURI());
+    return new String(Files.readAllBytes(path));
+  }
+
+  private void loadSegments(StorageRepository repository) throws IOException, URISyntaxException {
+    String segmentsJson = getJsonResource("local-test-cases/segments.json");
+    List<Segment> segments =
+        new JSON().deserialize(segmentsJson, new TypeToken<List<Segment>>() {}.getType());
+    assertFalse(segments.isEmpty());
+    for (Segment segment : segments) {
+      repository.setSegment(segment.getIdentifier(), segment);
     }
   }
 }

--- a/src/test/java/io/harness/cf/client/api/FFUseCaseTest.java
+++ b/src/test/java/io/harness/cf/client/api/FFUseCaseTest.java
@@ -1,40 +1,23 @@
 package io.harness.cf.client.api;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import com.google.gson.JsonObject;
 import io.harness.cf.client.dto.Target;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
-import org.testng.Assert;
-import org.testng.ITest;
-import org.testng.annotations.Test;
-import org.testng.annotations.BeforeMethod;
-
-import java.lang.reflect.Method;
 
 @Slf4j
-public class FFUseCaseTest implements ITest {
+public class FFUseCaseTest {
 
   private final TestCase testCase;
   private final Evaluator evaluator;
-
-  private final ThreadLocal<String> testName = new ThreadLocal<>();
 
   public FFUseCaseTest(@NonNull final TestCase testCase, @NonNull final Evaluator evaluator) {
     this.testCase = testCase;
     this.evaluator = evaluator;
   }
 
-  @BeforeMethod
-  public void BeforeMethod(Method method, Object[] testData){
-    testName.set(testCase.getTestName() + "_with_target_" +testCase.getTargetIdentifier());
-  }
-
-  @Override
-  public String getTestName() {
-    return testName.get();
-  }
-
-  @Test
   public void runTestCase() {
     log.info(
         String.format(
@@ -83,6 +66,6 @@ public class FFUseCaseTest implements ITest {
         String.format(
             "Test case: %s with identifier %s ",
             testCase.getFile(), testCase.getTargetIdentifier());
-    Assert.assertEquals(testCase.getExpectedValue(), got, msg);
+    assertEquals(testCase.getExpectedValue(), got, msg);
   }
 }

--- a/src/test/java/io/harness/cf/client/api/MetricsProcessorTest.java
+++ b/src/test/java/io/harness/cf/client/api/MetricsProcessorTest.java
@@ -1,6 +1,7 @@
 package io.harness.cf.client.api;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -17,9 +18,11 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
-import org.mockito.*;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 
 @Slf4j
 public class MetricsProcessorTest implements MetricsCallback {
@@ -28,7 +31,7 @@ public class MetricsProcessorTest implements MetricsCallback {
 
   private MetricsProcessor metricsProcessor;
 
-  @BeforeMethod
+  @BeforeEach
   public void setup() {
     MockitoAnnotations.openMocks(this);
     metricsProcessor =

--- a/src/test/resources/local-test-cases/percentage-rollout-with-zero-weights.json
+++ b/src/test/resources/local-test-cases/percentage-rollout-with-zero-weights.json
@@ -1,0 +1,78 @@
+[
+  {
+    "defaultServe": {
+      "variation": "variationA"
+    },
+    "environment": "Production",
+    "feature": "feature1",
+    "kind": "string",
+    "offVariation": "variationB",
+    "prerequisites": [],
+    "project": "FFdevqa",
+    "rules": [
+      {
+        "clauses": [
+          {
+            "attribute": "",
+            "id": "99d71036-bbb3-44a5-b79f-dee08e0209e2",
+            "negate": false,
+            "op": "segmentMatch",
+            "values": [
+              "featuretargetgroup"
+            ]
+          }
+        ],
+        "priority": 0,
+        "ruleId": "32a51235-3c68-4109-82e1-3a4ddf565230",
+        "serve": {
+          "distribution": {
+            "bucketBy": "identifier",
+            "variations": [
+              {
+                "variation": "variationA",
+                "weight": 25
+              },
+              {
+                "variation": "variationB",
+                "weight": 50
+              },
+              {
+                "variation": "variationC",
+                "weight": 25
+              },
+              {
+                "variation": "nextEmail",
+                "weight": 0
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "state": "off",
+    "variationToTargetMap": null,
+    "variations": [
+      {
+        "identifier": "variationA",
+        "name": "variationA",
+        "value": "A"
+      },
+      {
+        "identifier": "variationB",
+        "name": "variationB",
+        "value": "B"
+      },
+      {
+        "identifier": "variationC",
+        "name": "variationC",
+        "value": "C"
+      },
+      {
+        "identifier": "variationD",
+        "name": "variationD",
+        "value": "D"
+      }
+    ],
+    "version": 2
+  }
+]

--- a/src/test/resources/local-test-cases/segments.json
+++ b/src/test/resources/local-test-cases/segments.json
@@ -1,0 +1,21 @@
+[
+  {
+    "environment": "Production",
+    "excluded": [],
+    "identifier": "featuretargetgroup",
+    "included": [],
+    "name": "featuretargetgroup",
+    "rules": [
+      {
+        "attribute": "identifier",
+        "id": "7ccfe4f4-b5b4-4d45-9eae-ce2666210487",
+        "negate": false,
+        "op": "ends_with",
+        "values": [
+          "@harness.io"
+        ]
+      }
+    ],
+    "version": 2
+  }
+]


### PR DESCRIPTION
Adds additional test coverage to Evaluator class. In particular:
- Tests for percentage rollout and different clause types (starts with, ends with, match, in, etc)
- Additional tests to ensure a variation is not returned in percentage rollout if it's set to 0%
- Swapped out testng for junit5 - allows use of new annotations + easier naming of dynamic tests
