### PR TITLE
FFM-5251 - Merge FFM-5149 (flags out of sync) from 1.0.5.X to main

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,12 +81,12 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>3.9.1</version>
+            <version>4.9.0</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>logging-interceptor</artifactId>
-            <version>3.9.1</version>
+            <version>4.9.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>

--- a/src/main/java/io/harness/cf/client/api/PollingProcessor.java
+++ b/src/main/java/io/harness/cf/client/api/PollingProcessor.java
@@ -1,6 +1,8 @@
 package io.harness.cf.client.api;
 
 import com.google.common.util.concurrent.AbstractScheduledService;
+import com.google.common.util.concurrent.MoreExecutors;
+import io.harness.cf.client.common.ScheduledServiceStateLogger;
 import io.harness.cf.client.connector.Connector;
 import io.harness.cf.client.connector.ConnectorException;
 import io.harness.cf.model.FeatureConfig;
@@ -29,6 +31,9 @@ class PollingProcessor extends AbstractScheduledService {
     this.pollIntervalSeconds = pollIntervalSeconds;
     this.repository = repository;
     this.callback = callback;
+    this.addListener(
+        new ScheduledServiceStateLogger(PollingProcessor.class.getSimpleName()),
+        MoreExecutors.directExecutor());
   }
 
   public CompletableFuture<List<FeatureConfig>> retrieveFlags() {

--- a/src/main/java/io/harness/cf/client/common/ScheduledServiceStateLogger.java
+++ b/src/main/java/io/harness/cf/client/common/ScheduledServiceStateLogger.java
@@ -1,0 +1,37 @@
+package io.harness.cf.client.common;
+
+import com.google.common.util.concurrent.Service;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@AllArgsConstructor
+public class ScheduledServiceStateLogger extends Service.Listener {
+  private final String name;
+
+  @Override
+  public void starting() {
+    log.info("{}: ScheduledService starting", name);
+  }
+
+  @Override
+  public void running() {
+    log.info("{}: ScheduledService running", name);
+  }
+
+  @Override
+  public void stopping(Service.State from) {
+    log.info("{}: ScheduledService stopping [from={}]", name, from);
+  }
+
+  @Override
+  public void terminated(Service.State from) {
+    log.info("{}: ScheduledService terminated [from={}]", name, from);
+  }
+
+  @Override
+  public void failed(Service.State from, Throwable failure) {
+    log.warn("{}: ScheduledService failed [from={} message={}]", name, from, failure.getMessage());
+    log.warn(name + ": ScheduledService failed exception", failure);
+  }
+}

--- a/src/main/java/io/harness/cf/client/connector/EventSource.java
+++ b/src/main/java/io/harness/cf/client/connector/EventSource.java
@@ -77,6 +77,7 @@ public class EventSource implements ServerSentEvent.Listener, AutoCloseable, Ser
 
   @Override
   public void onOpen(ServerSentEvent serverSentEvent, Response response) {
+    log.info("EventSource onOpen");
     if (updater != null) {
       log.info("EventSource connected!");
       updater.onConnected();
@@ -85,7 +86,7 @@ public class EventSource implements ServerSentEvent.Listener, AutoCloseable, Ser
 
   @Override
   public void onMessage(ServerSentEvent sse, String id, String event, String message) {
-    log.info("EventSource message received {}", message);
+    log.info("EventSource onMessage {}", message);
     Message msg = gson.fromJson(message, Message.class);
     updater.update(msg);
   }
@@ -104,7 +105,11 @@ public class EventSource implements ServerSentEvent.Listener, AutoCloseable, Ser
   @Override
   public boolean onRetryError(
       ServerSentEvent serverSentEvent, Throwable throwable, Response response) {
-    log.warn("EventSource onRetryError");
+    log.warn(
+        "EventSource onRetryError [throwable={} message={}]",
+        throwable.getClass().getSimpleName(),
+        throwable.getMessage());
+    log.trace("onRetryError exception", throwable);
     updater.onError();
     if (response != null) {
       return response.code() == 429 || response.code() >= 500;
@@ -114,7 +119,7 @@ public class EventSource implements ServerSentEvent.Listener, AutoCloseable, Ser
 
   @Override
   public void onClosed(ServerSentEvent serverSentEvent) {
-    log.info("EventSource disconnected");
+    log.info("EventSource onClosed - disconnected");
     updater.onDisconnected();
   }
 

--- a/src/main/java/io/harness/cf/client/connector/HarnessConfig.java
+++ b/src/main/java/io/harness/cf/client/connector/HarnessConfig.java
@@ -20,4 +20,7 @@ public class HarnessConfig {
   @Builder.Default int readTimeout = 30000;
   /** timeout in milliseconds for writing data to CF Server */
   @Builder.Default int writeTimeout = 10000;
+
+  /** read timeout in minutes for SSE connections */
+  @Builder.Default long sseReadTimeout = 1;
 }

--- a/src/main/java/io/harness/cf/client/connector/HarnessConnector.java
+++ b/src/main/java/io/harness/cf/client/connector/HarnessConnector.java
@@ -221,6 +221,7 @@ public class HarnessConnector implements Connector, AutoCloseable {
           featureConfig.size(),
           this.environment,
           this.cluster);
+      log.info("Got the following features: " + featureConfig);
       return featureConfig;
     } catch (ApiException e) {
       log.error(

--- a/src/main/java/io/harness/cf/client/connector/HarnessConnector.java
+++ b/src/main/java/io/harness/cf/client/connector/HarnessConnector.java
@@ -355,7 +355,7 @@ public class HarnessConnector implements Connector, AutoCloseable {
     map.put("Authorization", "Bearer " + token);
     map.put("API-Key", apiKey);
     log.info("Initialize new EventSource instance");
-    eventSource = new EventSource(sseUrl, map, updater);
+    eventSource = new EventSource(sseUrl, map, updater, Math.max(options.getSseReadTimeout(), 1));
     return eventSource;
   }
 


### PR DESCRIPTION
**What**
SSE client should avoid using a read timeout of 0 since if the socket is not gracefully shutdown we have no way to detect that the socket is dead. Instead enforce a default read time out > 0 to force the connection to refresh and remove any stale socket. This change integrates the original bug fix FFM-5149 from 1.0.5.X into main. Main has previsouly been refactored and diverged so a 1:1 merge is not possible so a re-implementation has been done.

Additional changes:
- okhttp bumped from 3.9.1 to 4.9.0 to match 1.0.5.X version
- sseTimeout is now defined in HarnessConfig since Config was deprecated
- Fixed an issue where Poller would not restart on SSE disconnect due to the starttime not being set
- Added additional logging around socket events and ScheduledService states 

**Why**
This will allow the client to self heal in the event of a broken connection and avoid a situtation where the client gets out of sync with the FF server.

**Testing**
Manual testing, checked client was able to recover its connection even after the socket was broken on purpose.