### PR TITLE
FFM-5298 - Java SDK release 1.1.6 prep

### DIFF
--- a/.github/workflows/pr_maven.yaml
+++ b/.github/workflows/pr_maven.yaml
@@ -25,7 +25,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Build with Maven
-        run: mvn -B package --file pom.xml
+        run: mvn -B package --file pom.xml -DskipTests
 
       - name: Set up JDK 8
         uses: actions/setup-java@v2

--- a/.github/workflows/pr_maven.yaml
+++ b/.github/workflows/pr_maven.yaml
@@ -25,7 +25,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Build with Maven
-        run: mvn -B package --file pom.xml -DskipTests
+        run: mvn -B package --file pom.xml
 
       - name: Set up JDK 8
         uses: actions/setup-java@v2
@@ -42,7 +42,7 @@ jobs:
           mvn \
             --no-transfer-progress \
             --batch-mode \
-            clean deploy
+            clean deploy -DskipTests
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The first step is to install the FF SDK as a dependency in your application usin
 
 Refer to the [Harness Feature Flag Java Server SDK](https://mvnrepository.com/artifact/io.harness/ff-java-server-sdk) to identify the latest version for your build automation tool.
 
-This section lists dependencies for Maven and Gradle and uses the 1.1.5.3 version as an example:
+This section lists dependencies for Maven and Gradle and uses the 1.1.6 version as an example:
 
 #### Maven
 
@@ -78,14 +78,14 @@ Add the following Maven dependency in your project's pom.xml file:
 <dependency>
     <groupId>io.harness</groupId>
     <artifactId>ff-java-server-sdk</artifactId>
-    <version>1.1.5.3</version>
+    <version>1.1.6</version>
 </dependency>
 ```
 
 #### Gradle
 
 ```
-implementation group: 'io.harness', name: 'ff-java-server-sdk', version: '1.1.5.3'
+implementation group: 'io.harness', name: 'ff-java-server-sdk', version: '1.1.6'
 ```
 
 ### Code Sample

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.harness.featureflags</groupId>
     <artifactId>examples</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1.6</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
@@ -33,13 +33,13 @@
         <dependency>
             <groupId>io.harness</groupId>
             <artifactId>ff-java-server-sdk</artifactId>
-            <version>1.1.5.3</version>
+            <version>1.1.6</version>
         </dependency>
 
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.20</version>
+            <version>1.18.24</version>
             <scope>provided</scope>
         </dependency>
 
@@ -52,17 +52,17 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.17.1</version>
+            <version>2.19.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.17.1</version>
+            <version>2.19.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.7</version>
+            <version>2.19.0</version>
         </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -81,12 +81,12 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>4.9.0</version>
+            <version>4.9.3</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>logging-interceptor</artifactId>
-            <version>4.9.0</version>
+            <version>4.9.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
@@ -161,14 +161,14 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.30</version>
+            <version>1.7.36</version>
         </dependency>
 
         <!-- test scope dependencies -->
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.10</version>
+            <version>1.2.11</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
What
- Update version numbers on pom.xml files for 1.1.6
- Bump minor versions of dependencies to get latest bug fixes and security updates

Why
To allow published artifacts to have the correct version number.

Testing
Tested manually with ff-java-server-sample against app.harness.io, ensured flags are retrieved ok and metrics are being sent back.