### PR TITLE
FFM-5306 - Update Java SDK to Match Variations for Prereqs With Ident…

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The first step is to install the FF SDK as a dependency in your application usin
 
 Refer to the [Harness Feature Flag Java Server SDK](https://mvnrepository.com/artifact/io.harness/ff-java-server-sdk) to identify the latest version for your build automation tool.
 
-This section lists dependencies for Maven and Gradle and uses the 1.1.6 version as an example:
+This section lists dependencies for Maven and Gradle and uses the 1.1.7 version as an example:
 
 #### Maven
 
@@ -78,14 +78,14 @@ Add the following Maven dependency in your project's pom.xml file:
 <dependency>
     <groupId>io.harness</groupId>
     <artifactId>ff-java-server-sdk</artifactId>
-    <version>1.1.6</version>
+    <version>1.1.7</version>
 </dependency>
 ```
 
 #### Gradle
 
 ```
-implementation group: 'io.harness', name: 'ff-java-server-sdk', version: '1.1.6'
+implementation group: 'io.harness', name: 'ff-java-server-sdk', version: '1.1.7'
 ```
 
 ### Code Sample

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.harness.featureflags</groupId>
     <artifactId>examples</artifactId>
-    <version>1.1.6</version>
+    <version>1.1.7</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>io.harness</groupId>
             <artifactId>ff-java-server-sdk</artifactId>
-            <version>1.1.6</version>
+            <version>1.1.7</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.harness</groupId>
     <artifactId>ff-java-server-sdk</artifactId>
-    <version>1.1.6.1</version>
+    <version>1.1.7</version>
     <packaging>jar</packaging>
     <name>Harness Feature Flag Java Server SDK</name>
     <description>Harness Feature Flag Java Server SDK</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.harness</groupId>
     <artifactId>ff-java-server-sdk</artifactId>
-    <version>1.1.6</version>
+    <version>1.1.6.1</version>
     <packaging>jar</packaging>
     <name>Harness Feature Flag Java Server SDK</name>
     <description>Harness Feature Flag Java Server SDK</description>

--- a/src/main/java/io/harness/cf/client/api/Evaluator.java
+++ b/src/main/java/io/harness/cf/client/api/Evaluator.java
@@ -337,7 +337,8 @@ class Evaluator implements Evaluation {
             preReqFeatureConfig.get().getFeature(),
             validPreReqVariations);
         if (validPreReqVariations.stream()
-            .noneMatch(element -> element.contains(preReqEvaluatedVariation.get().getValue()))) {
+            .noneMatch(
+                element -> element.contains(preReqEvaluatedVariation.get().getIdentifier()))) {
           return false;
         } else {
           return checkPreRequisite(preReqFeatureConfig.get(), target);

--- a/src/test/java/io/harness/cf/client/api/EvaluatorTest.java
+++ b/src/test/java/io/harness/cf/client/api/EvaluatorTest.java
@@ -1,10 +1,13 @@
 package io.harness.cf.client.api;
 
 import static io.harness.cf.client.api.Operators.*;
+import static io.harness.cf.model.FeatureConfig.KindEnum.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import com.google.gson.reflect.TypeToken;
 import io.harness.cf.JSON;
 import io.harness.cf.client.dto.Target;
@@ -187,12 +190,26 @@ public class EvaluatorTest {
 
     final Target target = Target.builder().identifier("dummy_ident").name("dummy_name").build();
 
-    Optional<Variation> result =
-        eval.evaluate("FeatureFlagWithDependency", target, FeatureConfig.KindEnum.BOOLEAN, null);
-    assertTrue(result.isPresent());
+    // if the main flag doesn't return the expected value for each, we know the dependant flag is
+    // not evaluating properly
 
-    // if the main flag doesn't return true, we know the dependant flag is not evaluating properly
+    Optional<Variation> result;
+    result = eval.evaluate("FeatureFlagWithDependency", target, BOOLEAN, null);
+    assertTrue(result.isPresent());
     assertEquals("true", result.get().getValue());
+
+    result = eval.evaluate("StringMultivariateFeatureFlagWithDependency", target, STRING, null);
+    assertTrue(result.isPresent());
+    assertEquals("value1", result.get().getValue());
+
+    result = eval.evaluate("JsonMultivariateFeatureFlagWithDependency", target, JSON, null);
+    assertTrue(result.isPresent());
+    JsonObject json = (JsonObject) new JsonParser().parse(result.get().getValue());
+    assertEquals("value1", json.get("test").getAsString());
+
+    result = eval.evaluate("NumberMultivariateFeatureFlagWithDependency", target, INT, null);
+    assertTrue(result.isPresent());
+    assertEquals("1", result.get().getValue());
   }
 
   @Test

--- a/src/test/java/io/harness/cf/client/api/EvaluatorTest.java
+++ b/src/test/java/io/harness/cf/client/api/EvaluatorTest.java
@@ -33,7 +33,7 @@ public class EvaluatorTest {
     final StorageRepository repository = new StorageRepository(new CaffeineCache(100), null, null);
     evaluator = new Evaluator(repository);
 
-    loadSegments(repository);
+    loadSegments(repository, "local-test-cases/segments.json");
 
     final String featuresJson =
         getJsonResource("local-test-cases/percentage-rollout-with-zero-weights.json");
@@ -178,6 +178,24 @@ public class EvaluatorTest {
   }
 
   @Test
+  public void shouldCorrectlyEvaluatePrereqsIfIdAndValueDiffer() throws Exception {
+    final StorageRepository repo = new StorageRepository(new CaffeineCache(100), null, null);
+    final Evaluator eval = new Evaluator(repo);
+
+    loadSegments(repo, "local-test-cases/segments.json");
+    loadFlags(repo, "local-test-cases/pre-req-id-and-value-differ.json");
+
+    final Target target = Target.builder().identifier("dummy_ident").name("dummy_name").build();
+
+    Optional<Variation> result =
+        eval.evaluate("FeatureFlagWithDependency", target, FeatureConfig.KindEnum.BOOLEAN, null);
+    assertTrue(result.isPresent());
+
+    // if the main flag doesn't return true, we know the dependant flag is not evaluating properly
+    assertEquals("true", result.get().getValue());
+  }
+
+  @Test
   public void testEvaluateRules() throws InterruptedException {
 
     final int threadCount = 10;
@@ -238,13 +256,26 @@ public class EvaluatorTest {
     return new String(Files.readAllBytes(path));
   }
 
-  private void loadSegments(StorageRepository repository) throws IOException, URISyntaxException {
-    String segmentsJson = getJsonResource("local-test-cases/segments.json");
+  private void loadSegments(StorageRepository repository, String resourceName)
+      throws IOException, URISyntaxException {
+    String segmentsJson = getJsonResource(resourceName);
     List<Segment> segments =
         new JSON().deserialize(segmentsJson, new TypeToken<List<Segment>>() {}.getType());
     assertFalse(segments.isEmpty());
     for (Segment segment : segments) {
       repository.setSegment(segment.getIdentifier(), segment);
+    }
+  }
+
+  private void loadFlags(StorageRepository repository, String resourceName)
+      throws IOException, URISyntaxException {
+    final String featuresJson = getJsonResource(resourceName);
+    final List<FeatureConfig> featList =
+        new JSON().deserialize(featuresJson, new TypeToken<List<FeatureConfig>>() {}.getType());
+    assertFalse(featList.isEmpty());
+
+    for (FeatureConfig config : featList) {
+      repository.setFlag(config.getFeature(), config);
     }
   }
 }

--- a/src/test/java/io/harness/cf/client/api/FFUseCaseTest.java
+++ b/src/test/java/io/harness/cf/client/api/FFUseCaseTest.java
@@ -21,11 +21,14 @@ public class FFUseCaseTest {
   public void runTestCase() {
     log.info(
         String.format(
-            "Use case '%s' with target '%s' and expected value '%b'",
-            testCase.getFile(), testCase.getTargetIdentifier(), testCase.getExpectedValue()));
-    String noTarget = "_no_target";
+            "Use case '%s' with target '%s' and flag '%s' is expected to be '%b'",
+            testCase.getFile(),
+            testCase.getTargetIdentifier(),
+            testCase.getFlag(),
+            testCase.getExpectedValue()));
+
     Target target = null;
-    if (!noTarget.equals(testCase.getTargetIdentifier())) {
+    if (!"_no_target".equals(testCase.getTargetIdentifier())) {
       if (testCase.getFileData().getTargets() != null) {
         for (final Target item : testCase.getFileData().getTargets()) {
           if (item != null && item.getIdentifier().equals(testCase.getTargetIdentifier())) {
@@ -37,35 +40,34 @@ public class FFUseCaseTest {
     }
 
     Object got = null;
-    switch (testCase.getFileData().getFlag().getKind()) {
+    switch (testCase.getFlagKind()) {
       case BOOLEAN:
-        got =
-            evaluator.boolVariation(
-                testCase.getFileData().getFlag().getFeature(), target, false, null);
+        got = evaluator.boolVariation(testCase.getFlag(), target, false, null);
         break;
 
       case STRING:
-        got =
-            evaluator.stringVariation(
-                testCase.getFileData().getFlag().getFeature(), target, "", null);
+        got = evaluator.stringVariation(testCase.getFlag(), target, "", null);
         break;
 
       case INT:
-        got =
-            evaluator.numberVariation(
-                testCase.getFileData().getFlag().getFeature(), target, 0, null);
+        got = evaluator.numberVariation(testCase.getFlag(), target, 0, null);
         break;
 
       case JSON:
-        got =
-            evaluator.jsonVariation(
-                testCase.getFileData().getFlag().getFeature(), target, new JsonObject(), null);
+        got = evaluator.jsonVariation(testCase.getFlag(), target, new JsonObject(), null);
         break;
     }
+
+    log.info("FLAG    : " + testCase.getFlag());
+    log.info("TARGET  : " + (target == null ? "(none)" : target.getIdentifier()));
+    log.info("EXPECTED: " + testCase.getExpectedValue());
+    log.info("GOT     : " + got);
+
     String msg =
         String.format(
             "Test case: %s with identifier %s ",
             testCase.getFile(), testCase.getTargetIdentifier());
+
     assertEquals(testCase.getExpectedValue(), got, msg);
   }
 }

--- a/src/test/java/io/harness/cf/client/api/TestCase.java
+++ b/src/test/java/io/harness/cf/client/api/TestCase.java
@@ -1,5 +1,6 @@
 package io.harness.cf.client.api;
 
+import io.harness.cf.model.FeatureConfig;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -9,6 +10,8 @@ public class TestCase {
   private final String file;
   private final String targetIdentifier;
   private final Object expectedValue;
+  private final String flag;
+  private final FeatureConfig.KindEnum flagKind;
   private final TestFileData fileData;
   private final String testName;
 }

--- a/src/test/java/io/harness/cf/client/api/TestFileData.java
+++ b/src/test/java/io/harness/cf/client/api/TestFileData.java
@@ -3,19 +3,21 @@ package io.harness.cf.client.api;
 import io.harness.cf.client.dto.Target;
 import io.harness.cf.model.FeatureConfig;
 import io.harness.cf.model.Segment;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.ToString;
 
 @Builder
 @Data
 @AllArgsConstructor
+@ToString
 public class TestFileData {
   private String testFile;
-  private FeatureConfig flag;
+  private List<FeatureConfig> flags;
   private List<Target> targets;
   private List<Segment> segments;
-  private HashMap<String, Boolean> expected;
+  private List<Map<String, Object>> tests;
 }

--- a/src/test/resources/local-test-cases/pre-req-id-and-value-differ.json
+++ b/src/test/resources/local-test-cases/pre-req-id-and-value-differ.json
@@ -1,0 +1,64 @@
+[
+  {
+    "defaultServe": {
+      "variation": "true"
+    },
+    "environment": "myenv",
+    "feature": "FeatureFlagWithDependency",
+    "kind": "boolean",
+    "offVariation": "false",
+    "prerequisites": [
+      {
+        "ParentFeature": "b20619f3-ad8a-4b55-ab8c-b8466c0904dd",
+        "feature": "FeatureFlagWithMixedIdAndValues",
+        "variations": [
+          "On"
+        ]
+      }
+    ],
+    "project": "ffsynctest",
+    "rules": [],
+    "state": "on",
+    "variationToTargetMap": null,
+    "variations": [
+      {
+        "identifier": "true",
+        "name": "On",
+        "value": "true"
+      },
+      {
+        "identifier": "false",
+        "name": "Off",
+        "value": "false"
+      }
+    ],
+    "version": 5
+  },
+  {
+    "defaultServe": {
+      "variation": "On"
+    },
+    "environment": "myenv",
+    "feature": "FeatureFlagWithMixedIdAndValues",
+    "kind": "string",
+    "offVariation": "Off",
+    "prerequisites": [],
+    "project": "ffsynctest",
+    "rules": [],
+    "state": "on",
+    "variationToTargetMap": null,
+    "variations": [
+      {
+        "identifier": "On",
+        "name": "On",
+        "value": "true"
+      },
+      {
+        "identifier": "Off",
+        "name": "Off",
+        "value": "false"
+      }
+    ],
+    "version": 2
+  }
+]

--- a/src/test/resources/local-test-cases/pre-req-id-and-value-differ.json
+++ b/src/test/resources/local-test-cases/pre-req-id-and-value-differ.json
@@ -32,7 +32,7 @@
         "value": "false"
       }
     ],
-    "version": 5
+    "version": 9
   },
   {
     "defaultServe": {
@@ -59,6 +59,111 @@
         "value": "false"
       }
     ],
+    "version": 4
+  },
+  {
+    "defaultServe": {
+      "variation": "jsonName1"
+    },
+    "environment": "myenv",
+    "feature": "JsonMultivariateFeatureFlagWithDependency",
+    "kind": "json",
+    "offVariation": "jsonName2",
+    "prerequisites": [
+      {
+        "ParentFeature": "e6455822-0650-48ca-ac4d-d53c60cd617e",
+        "feature": "FeatureFlagWithMixedIdAndValues",
+        "variations": [
+          "On"
+        ]
+      }
+    ],
+    "project": "ffsynctest",
+    "rules": [],
+    "state": "on",
+    "variationToTargetMap": null,
+    "variations": [
+      {
+        "identifier": "jsonName1",
+        "name": "jsonName1",
+        "value": "{\"test\":\"value1\"}"
+      },
+      {
+        "identifier": "jsonName2",
+        "name": "jsonName2",
+        "value": "{\"test\":\"value2\"}"
+      }
+    ],
+    "version": 3
+  },
+  {
+    "defaultServe": {
+      "variation": "number1"
+    },
+    "environment": "myenv",
+    "feature": "NumberMultivariateFeatureFlagWithDependency",
+    "kind": "int",
+    "offVariation": "number2",
+    "prerequisites": [
+      {
+        "ParentFeature": "3c3130a3-9337-4af5-a708-978b862b6a45",
+        "feature": "FeatureFlagWithMixedIdAndValues",
+        "variations": [
+          "On"
+        ]
+      }
+    ],
+    "project": "ffsynctest",
+    "rules": [],
+    "state": "on",
+    "variationToTargetMap": null,
+    "variations": [
+      {
+        "identifier": "number1",
+        "name": "number1",
+        "value": "1"
+      },
+      {
+        "identifier": "number2",
+        "name": "number2",
+        "value": "2"
+      }
+    ],
     "version": 2
+  },
+  {
+    "defaultServe": {
+      "variation": "name1"
+    },
+    "environment": "myenv",
+    "feature": "StringMultivariateFeatureFlagWithDependency",
+    "kind": "string",
+    "offVariation": "name2",
+    "prerequisites": [
+      {
+        "ParentFeature": "e9ecd67a-d91f-49fd-af96-a2b085b8109a",
+        "feature": "FeatureFlagWithMixedIdAndValues",
+        "variations": [
+          "On"
+        ]
+      }
+    ],
+    "project": "ffsynctest",
+    "rules": [],
+    "state": "on",
+    "variationToTargetMap": null,
+    "variations": [
+      {
+        "identifier": "name1",
+        "name": "name1",
+        "value": "value1"
+      },
+      {
+        "identifier": "name2",
+        "name": "name2",
+        "value": "value2"
+      }
+    ],
+    "version": 3
   }
 ]

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -9,7 +9,7 @@
         </encoder>
     </appender>
     <logger name="io.harness.cf.client" level="DEBUG"/>
-    <logger name="io.harness.cf.client.api.MetricsProcessor" level="INFO"/>
+    <logger name="io.harness.cf.client.api.MetricsProcessor" level="WARN"/>
     <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>


### PR DESCRIPTION
FFM-5306 - Update Java SDK to Match Variations for Prereqs With Identifier Instead of Values

**What**
When a feature depends on another prereq feature being true, the evaluation fails if the value and identifier are different values in the prereq.

**Why**
The checkPreRequisite() method incorrectly uses the value of the prereq instead of the identifier.

**Testing**
Manual + unit testing. Created flags with prereqs on app.harness.io, exported JSON into a local test case and added a new test called shouldCorrectlyEvaluatePrereqsIfIdAndValueDiffer()