### PR TITLE
FFM-5376 - Java SDK - CVE Update openapi-generator maven plugin + GSON

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.10</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>31.0.1-jre</version>
@@ -193,7 +199,7 @@
             <plugin>
                 <groupId>org.openapitools</groupId>
                 <artifactId>openapi-generator-maven-plugin</artifactId>
-                <version>4.3.1</version>
+                <version>5.4.0</version>
                 <executions>
                     <execution>
                         <id>client</id>


### PR DESCRIPTION
What
Update openapi-generator Maven plugin to remove a CodeQL alert in generated code: TrustManager that accepts all certificates https://github.com/harness/ff-java-server-sdk/security/code-scanning/1

Also update Google GSON library to remove CVE-2022-25647 https://nvd.nist.gov/vuln/detail/CVE-2022-25647

Why
Remove unsecure packages and warnings from IntelliJ

Testing
Smoke tested SDK with newer versions, checked basic feature toggles are still working and no exception were reported