### PR TITLE
FFM-5389 - Java SDK - Add recursion when scanning ff-test-cases folder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -389,7 +389,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M5</version>
+                <version>3.0.0-M7</version>
                 <configuration>
                     <systemPropertyVariables>
                         <SDK>JAVA</SDK>


### PR DESCRIPTION
What
Allow Java SDK test cases to be run from any subfolder inside ff-test-cases if it ends with a JSON extension

Why
This will allow converted test cases to run which may be nested in folders

Testing
Tested manually with some test folders and unknown files