### PR TITLE
FFM-5389 - Adding JUnit5Xml30StatelessReporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The first step is to install the FF SDK as a dependency in your application usin
 
 Refer to the [Harness Feature Flag Java Server SDK](https://mvnrepository.com/artifact/io.harness/ff-java-server-sdk) to identify the latest version for your build automation tool.
 
-This section lists dependencies for Maven and Gradle and uses the 1.1.7 version as an example:
+This section lists dependencies for Maven and Gradle and uses the 1.1.6 version as an example:
 
 #### Maven
 
@@ -78,14 +78,14 @@ Add the following Maven dependency in your project's pom.xml file:
 <dependency>
     <groupId>io.harness</groupId>
     <artifactId>ff-java-server-sdk</artifactId>
-    <version>1.1.7</version>
+    <version>1.1.6</version>
 </dependency>
 ```
 
 #### Gradle
 
 ```
-implementation group: 'io.harness', name: 'ff-java-server-sdk', version: '1.1.7'
+implementation group: 'io.harness', name: 'ff-java-server-sdk', version: '1.1.6'
 ```
 
 ### Code Sample

--- a/pom.xml
+++ b/pom.xml
@@ -395,6 +395,9 @@
                         <SDK>JAVA</SDK>
                         <version>${project.version}</version>
                     </systemPropertyVariables>
+                    <statelessTestsetReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5Xml30StatelessReporter">
+                        <usePhrasedTestCaseMethodName>true</usePhrasedTestCaseMethodName>
+                    </statelessTestsetReporter>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/test/java/io/harness/cf/client/api/EvaluatorIntegrationTest.java
+++ b/src/test/java/io/harness/cf/client/api/EvaluatorIntegrationTest.java
@@ -5,6 +5,7 @@ import io.harness.cf.model.FeatureConfig;
 import io.harness.cf.model.Segment;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
 
@@ -25,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class EvaluatorIntegrationTest {
   private final Gson gson = new Gson();
 
+  @DisplayName("ff-test-cases")
   @TestFactory
   public List<DynamicTest> getTestCases() throws Exception {
     final List<DynamicTest> list = new ArrayList<>();

--- a/src/test/java/io/harness/cf/client/api/FFUseCaseTest.java
+++ b/src/test/java/io/harness/cf/client/api/FFUseCaseTest.java
@@ -2,8 +2,11 @@ package io.harness.cf.client.api;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import io.harness.cf.client.dto.Target;
+import io.harness.cf.model.FeatureConfig;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
@@ -68,6 +71,11 @@ public class FFUseCaseTest {
             "Test case: %s with identifier %s ",
             testCase.getFile(), testCase.getTargetIdentifier());
 
-    assertEquals(testCase.getExpectedValue(), got, msg);
+    if (testCase.getFlagKind() == FeatureConfig.KindEnum.JSON) {
+      JsonElement expectedJson = JsonParser.parseString((String) testCase.getExpectedValue());
+      assertEquals(expectedJson, got, msg);
+    } else {
+      assertEquals(testCase.getExpectedValue(), got, msg);
+    }
   }
 }


### PR DESCRIPTION
FFM-5389 - Adding JUnit5Xml30StatelessReporter to get dynamic tests reported in surefire reports

What
Adding extension JUnit5Xml30StatelessReporter so we can see dynamic test names in surefire reports.
Also fixed readme which is mentioning an unreleased version

Why
All test cases for dynamic tests are showing getTestCases(), we want to see the actual name of the dynamic test

Testing
Tested manually, checked XML output of surefire was showing more than just getTestCase