### PR TITLE
[FFM-5247] Fix Jacoco code coverage report

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -398,20 +398,22 @@
                     <statelessTestsetReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5Xml30StatelessReporter">
                         <usePhrasedTestCaseMethodName>true</usePhrasedTestCaseMethodName>
                     </statelessTestsetReporter>
+                    <argLine>${surefireArgLine} -Xmx1024m -noverify</argLine>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.7</version>
+                <version>0.8.8</version>
                 <executions>
                     <execution>
+                        <id>default-prepare-agent</id>
                         <goals>
                             <goal>prepare-agent</goal>
                         </goals>
                     </execution>
                     <execution>
-                        <id>report</id>
+                        <id>generate-code-coverage-report</id>
                         <phase>test</phase>
                         <goals>
                             <goal>report</goal>
@@ -421,6 +423,7 @@
                 <configuration>
                     <propertyName>SDK</propertyName>
                     <propertyName>version</propertyName>
+                    <propertyName>surefireArgLine</propertyName>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
[FFM-5247] Fix Jacoco code coverage report

What
Fix the Jacoco code coverage plugin to correctly generate coverage reports. Surefire plugin will stomp over the command line arguments needed by Jacoco and they need to be preserved with some additional configuration.

Why
We want to be able to generate Jacoco code coverage reports so that downstream pipelines can consume coverage information for better reporting

Testing
Confirmed target/jacoco.exec and ./target/site/jacoco/index.html exists after building via cmd line

[FFM-5247]: https://harness.atlassian.net/browse/FFM-5247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ