### PR TITLE
FFM-5928 - Fix java.lang.NoSuchMethodError caused by kotlin-stdlib 

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The first step is to install the FF SDK as a dependency in your application usin
 
 Refer to the [Harness Feature Flag Java Server SDK](https://mvnrepository.com/artifact/io.harness/ff-java-server-sdk) to identify the latest version for your build automation tool.
 
-This section lists dependencies for Maven and Gradle and uses the 1.1.7 version as an example:
+This section lists dependencies for Maven and Gradle and uses the 1.1.8 version as an example:
 
 #### Maven
 
@@ -78,14 +78,14 @@ Add the following Maven dependency in your project's pom.xml file:
 <dependency>
     <groupId>io.harness</groupId>
     <artifactId>ff-java-server-sdk</artifactId>
-    <version>1.1.7</version>
+    <version>1.1.8</version>
 </dependency>
 ```
 
 #### Gradle
 
 ```
-implementation group: 'io.harness', name: 'ff-java-server-sdk', version: '1.1.7'
+implementation group: 'io.harness', name: 'ff-java-server-sdk', version: '1.1.8'
 ```
 
 ### Code Sample

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.harness.featureflags</groupId>
     <artifactId>examples</artifactId>
-    <version>1.1.8-SNAPSHOT</version>
+    <version>1.1.8</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>io.harness</groupId>
             <artifactId>ff-java-server-sdk</artifactId>
-            <version>1.1.8-SNAPSHOT</version>
+            <version>1.1.8</version>
         </dependency>
 
         <dependency>

--- a/examples/src/main/java/io/harness/ff/examples/GettingStarted.java
+++ b/examples/src/main/java/io/harness/ff/examples/GettingStarted.java
@@ -34,13 +34,18 @@ public class GettingStarted {
             scheduler.scheduleAtFixedRate(
                     () -> {
                         boolean result = cfClient.boolVariation(flagName, target, false);
-                        System.out.println("Boolean variation is " + result);
+                        System.out.println("Flag '" + flagName + "' Boolean variation is " + result);
                     },
                     0,
                     10,
                     TimeUnit.SECONDS);
 
+
+            TimeUnit.MINUTES.sleep(15);
+
             // Close the SDK
+            System.out.println("Cleaning up...");
+            scheduler.shutdownNow();
             cfClient.close();
 
         } catch (Exception e) {

--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,12 @@
             <groupId>org.mapdb</groupId>
             <artifactId>mapdb</artifactId>
             <version>3.0.8</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jetbrains.kotlin</groupId>
+                    <artifactId>kotlin-stdlib</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.harness</groupId>
     <artifactId>ff-java-server-sdk</artifactId>
-    <version>1.1.8-SNAPSHOT</version>
+    <version>1.1.8</version>
     <packaging>jar</packaging>
     <name>Harness Feature Flag Java Server SDK</name>
     <description>Harness Feature Flag Java Server SDK</description>


### PR DESCRIPTION
FFM-5928 - Fix java.lang.NoSuchMethodError caused by conflicting versions of kotlin-stdlib on the classpath

What
Exclude kotlin-stdlib being brought in by mapdb.
Minor fix to GettingStart example to stop it from closing the client too soon.

Why
okhttp 4.9.3 uses a newer version of the kotlin-stdlib which is conflicting with a version brought in by mapdb

Testing
Tested with GettingStarted java sample using same instructions as on the README