### PR TITLE
FFM-5910 - Don't mask exceptions reported during authentication

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.harness.featureflags</groupId>
     <artifactId>examples</artifactId>
-    <version>1.1.8</version>
+    <version>1.1.9-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>io.harness</groupId>
             <artifactId>ff-java-server-sdk</artifactId>
-            <version>1.1.8</version>
+            <version>1.1.9-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.harness</groupId>
     <artifactId>ff-java-server-sdk</artifactId>
-    <version>1.1.8</version>
+    <version>1.1.9-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Harness Feature Flag Java Server SDK</name>
     <description>Harness Feature Flag Java Server SDK</description>

--- a/src/main/java/io/harness/cf/client/connector/HarnessConfig.java
+++ b/src/main/java/io/harness/cf/client/connector/HarnessConfig.java
@@ -3,10 +3,12 @@ package io.harness.cf.client.connector;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 @Builder
 @Getter
 @AllArgsConstructor
+@ToString
 public class HarnessConfig {
   public static final int MIN_FREQUENCY = 60;
 

--- a/src/main/java/io/harness/cf/client/connector/HarnessConnector.java
+++ b/src/main/java/io/harness/cf/client/connector/HarnessConnector.java
@@ -50,7 +50,7 @@ public class HarnessConnector implements Connector, AutoCloseable {
     this.options = options;
     this.api = new ClientApi(makeApiClient());
     this.metricsApi = new MetricsApi(makeMetricsApiClient());
-    log.info("Connector initialized");
+    log.info("Connector initialized, with options " + options);
   }
 
   protected ApiClient makeApiClient() {
@@ -180,6 +180,9 @@ public class HarnessConnector implements Connector, AutoCloseable {
       }
       log.error("Failed to get auth token", apiException);
       throw new ConnectorException(apiException.getMessage());
+    } catch (Throwable ex) {
+      log.error("Unexpected exception", ex);
+      throw ex;
     } finally {
       MDC.remove(REQUEST_ID_KEY);
     }


### PR DESCRIPTION
FFM-5910 - Don't mask exceptions reported during authentication

What
If we get any exceptions during authentication, make sure the stack trace is logged to make it easier to diagnose issues.

Why
During testing of the testgrid load test framework SDK hung due to a classpath conflict so authentication did not complete (and no error was reported because the exception was swallowed)

Testing
Tested against the ff-sdk-testgrid java container