### PR TITLE
FFM-5247 - Java SDK - Improve unit test coverage (CfClient)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,6 +198,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>4.9.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/io/harness/cf/client/api/CfClient.java
+++ b/src/main/java/io/harness/cf/client/api/CfClient.java
@@ -129,4 +129,10 @@ public class CfClient implements AutoCloseable {
   public void destroy() {
     close();
   }
+
+  /* Package private */
+
+  InnerClient getInnerClient() {
+    return client;
+  }
 }

--- a/src/main/java/io/harness/cf/client/api/InnerClient.java
+++ b/src/main/java/io/harness/cf/client/api/InnerClient.java
@@ -52,6 +52,8 @@ class InnerClient
 
   private Date pollerStartedAt;
 
+  private static final String MISSING_SDK_KEY = "SDK key cannot be empty!";
+
   private final ConcurrentHashMap<Event, CopyOnWriteArrayList<Consumer<String>>> events =
       new ConcurrentHashMap<>();
 
@@ -62,8 +64,8 @@ class InnerClient
   @Deprecated
   public InnerClient(@NonNull final String sdkKey, @NonNull final Config options) {
     if (Strings.isNullOrEmpty(sdkKey)) {
-      log.error("SDK key cannot be empty!");
-      return;
+      log.error(MISSING_SDK_KEY);
+      throw new IllegalArgumentException(MISSING_SDK_KEY);
     }
     HarnessConfig config =
         HarnessConfig.builder()
@@ -79,8 +81,8 @@ class InnerClient
 
   public InnerClient(@NonNull final String sdkKey, @NonNull final BaseConfig options) {
     if (Strings.isNullOrEmpty(sdkKey)) {
-      log.error("SDK key cannot be empty!");
-      return;
+      log.error(MISSING_SDK_KEY);
+      throw new IllegalArgumentException(MISSING_SDK_KEY);
     }
 
     HarnessConfig config = HarnessConfig.builder().build();
@@ -387,5 +389,11 @@ class InnerClient
     metricsProcessor.close();
     connector.close();
     log.info("All resources released and client closed");
+  }
+
+  /* Package private */
+
+  BaseConfig getOptions() {
+    return options;
   }
 }

--- a/src/test/java/io/harness/cf/client/api/CfClientTest.java
+++ b/src/test/java/io/harness/cf/client/api/CfClientTest.java
@@ -1,0 +1,375 @@
+package io.harness.cf.client.api;
+
+import static io.harness.cf.client.api.TestUtils.*;
+import static io.harness.cf.client.api.TestUtils.makeMockJsonResponse;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.gson.JsonObject;
+import io.harness.cf.client.common.Cache;
+import io.harness.cf.client.connector.Connector;
+import io.harness.cf.client.connector.ConnectorException;
+import io.harness.cf.client.connector.Service;
+import io.harness.cf.client.connector.Updater;
+import io.harness.cf.client.dto.Target;
+import io.harness.cf.model.FeatureConfig;
+import io.harness.cf.model.Metrics;
+import io.harness.cf.model.Segment;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import lombok.NonNull;
+import lombok.SneakyThrows;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class CfClientTest {
+
+  private final MockWebServer mockWebServer = new MockWebServer();
+  private static final AtomicInteger onEventCounter = new AtomicInteger();
+
+  private static final Target target =
+      Target.builder().identifier("andybody@harness.io").name("andybody@harness.io").build();
+
+  @AfterEach
+  void afterAll() throws IOException {
+    mockWebServer.shutdown();
+  }
+
+  @Test
+  void shouldGetInstanceWithoutErrors() {
+    assertDoesNotThrow(CfClient::getInstance, "Exception should not be thrown");
+  }
+
+  @Test
+  void defaultConstructorShouldNotThrowException() {
+    assertDoesNotThrow(
+        () -> {
+          try (CfClient client = new CfClient(); ) {
+            client.initialize("dummyKey");
+          }
+        },
+        "Exception should not be thrown");
+  }
+
+  private interface AssertOptions {
+    void assertOptions(BaseConfig config);
+  }
+
+  @Test
+  void testConstructors() throws IOException {
+
+    final Config config =
+        Config.builder()
+            .streamEnabled(false)
+            .pollIntervalInSeconds(123)
+            .analyticsEnabled(false)
+            .globalTargetEnabled(false)
+            .frequency(321)
+            .bufferSize(999)
+            .allAttributesPrivate(true)
+            .privateAttributes(ImmutableSet.of("privateFeature1", "privateFeature2"))
+            .metricsServiceAcceptableDuration(9999)
+            .debug(true)
+            .cache(new DummyCache())
+            .build();
+
+    final AssertOptions asserter =
+        actualOptions -> {
+          assertFalse(actualOptions.isStreamEnabled());
+          assertEquals(123, actualOptions.getPollIntervalInSeconds());
+          assertFalse(actualOptions.isAnalyticsEnabled());
+          assertFalse(actualOptions.isGlobalTargetEnabled());
+          assertEquals(321, actualOptions.getFrequency());
+          assertEquals(999, actualOptions.getBufferSize());
+          assertTrue(actualOptions.isAllAttributesPrivate());
+          assertInstanceOf(Set.class, config.getPrivateAttributes());
+          assertEquals(2, config.getPrivateAttributes().size());
+          assertTrue(config.getPrivateAttributes().contains("privateFeature1"));
+          assertTrue(config.getPrivateAttributes().contains("privateFeature2"));
+          assertEquals(9999, config.getMetricsServiceAcceptableDuration());
+          assertTrue(actualOptions.isDebug());
+          assertInstanceOf(DummyCache.class, config.getCache());
+        };
+
+    try (final CfClient client = new CfClient("testsdkkey", config)) {
+      final BaseConfig actualOptions = client.getInnerClient().getOptions();
+      asserter.assertOptions(actualOptions);
+    }
+
+    try (final CfClient client = new CfClient("testsdkkey", (BaseConfig) config)) {
+      final BaseConfig actualOptions = client.getInnerClient().getOptions();
+      asserter.assertOptions(actualOptions);
+    }
+  }
+
+  @Test
+  void shouldFailIfEmptySdkKeyGiven() {
+    Exception thrown =
+        assertThrows(
+            IllegalArgumentException.class, () -> new CfClient(""), "Exception was not thrown");
+    assertInstanceOf(IllegalArgumentException.class, thrown);
+  }
+
+  @Test
+  void shouldAuthenticatedAgainstAuthEndpoint() throws IOException, URISyntaxException {
+    BaseConfig config =
+        BaseConfig.builder()
+            .pollIntervalInSeconds(1)
+            .analyticsEnabled(false)
+            .streamEnabled(false)
+            .build();
+
+    MockResponse mockedSuccessResponse =
+        makeMockJsonResponse(200, "{\"authToken\": \"" + makeDummyJwtToken() + "\"}");
+    MockResponse mockedFlagsSuccessResponse = makeMockJsonResponse(200, makeFeatureJson());
+    MockResponse mockedSegmentSuccessResponse = makeMockJsonResponse(200, makeSegmentsJson());
+
+    mockWebServer.enqueue(mockedSuccessResponse);
+    mockWebServer.enqueue(
+        mockedFlagsSuccessResponse); // Return some flags+segments to allow init to finish
+    mockWebServer.enqueue(mockedSegmentSuccessResponse);
+    mockWebServer.start();
+
+    try (CfClient client =
+        new CfClient(makeConnector(mockWebServer.getHostName(), mockWebServer.getPort()), config)) {
+      assertTimeoutPreemptively(
+          Duration.ofMillis(30_000),
+          client::waitForInitialization,
+          "CfClient did not initialize on time");
+    }
+  }
+
+  private static Stream<Arguments> variantsToTest() {
+    return Stream.of(
+        Arguments.of("boolVariation", (Consumer<CfClient>) CfClientTest::testBoolVariant),
+        Arguments.of("stringVariation", (Consumer<CfClient>) CfClientTest::testStringVariant),
+        Arguments.of("numberVariation", (Consumer<CfClient>) CfClientTest::testNumberVariant),
+        Arguments.of("jsonVariant", (Consumer<CfClient>) CfClientTest::testJsonVariant));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("variantsToTest")
+  void shouldGetVariantInPollingMode(String description, Consumer<CfClient> flagCallback)
+      throws IOException, URISyntaxException {
+    BaseConfig config =
+        BaseConfig.builder()
+            .pollIntervalInSeconds(1)
+            .analyticsEnabled(false)
+            .streamEnabled(false)
+            .build();
+
+    MockResponse mockedAuthResponse =
+        makeMockJsonResponse(200, "{\"authToken\": \"" + makeDummyJwtToken() + "\"}");
+    MockResponse mockedFlagsResponse = makeMockJsonResponse(200, makeBasicFeatureJson());
+    MockResponse mockedSegmentResponse = makeMockJsonResponse(200, makeSegmentsJson());
+    mockWebServer.enqueue(mockedAuthResponse);
+    mockWebServer.enqueue(mockedFlagsResponse);
+    mockWebServer.enqueue(mockedSegmentResponse);
+    mockWebServer.start();
+
+    try (CfClient client =
+        new CfClient(makeConnector(mockWebServer.getHostName(), mockWebServer.getPort()), config)) {
+      assertTimeoutPreemptively(
+          Duration.ofMillis(30_000),
+          client::waitForInitialization,
+          "CfClient did not initialize on time");
+
+      flagCallback.accept(client); // Run the actual test
+    }
+  }
+
+  private static void testBoolVariant(CfClient client) {
+    boolean value = client.boolVariation("simplebool", target, false);
+    assertTrue(value);
+  }
+
+  private static void testStringVariant(CfClient client) {
+    String value = client.stringVariation("simplestring", target, "DEFAULT");
+    assertEquals("on-string", value);
+  }
+
+  private static void testNumberVariant(CfClient client) {
+    double value = client.numberVariation("simplenumber", target, 0.123);
+    assertEquals(1, value);
+  }
+
+  private static void testJsonVariant(CfClient client) {
+    JsonObject value = client.jsonVariation("simplejson", target, new JsonObject());
+    assertEquals("on", value.get("value").getAsString());
+  }
+
+  static class TestWebServerDispatcher extends Dispatcher {
+    private final AtomicInteger version = new AtomicInteger(2);
+
+    @Override
+    @SneakyThrows
+    @NotNull
+    public MockResponse dispatch(@NotNull RecordedRequest recordedRequest)
+        throws InterruptedException {
+      System.out.println("DISPATCH GOT ------> " + recordedRequest.getPath());
+
+      switch (Objects.requireNonNull(recordedRequest.getPath())) {
+        case "/api/1.0/client/auth":
+          return makeAuthResponse();
+        case "/api/1.0/client/env/00000000-0000-0000-0000-000000000000/feature-configs?cluster=1":
+          return makeMockJsonResponse(200, makeBasicFeatureJson());
+        case "/api/1.0/client/env/00000000-0000-0000-0000-000000000000/target-segments?cluster=1":
+          return makeMockJsonResponse(200, makeSegmentsJson());
+        case "/api/1.0/stream?cluster=1":
+          return makeMockStreamResponse(
+              200, makeFlagPatchEvent("simplebool", version.getAndIncrement()));
+        case "/api/1.0/client/env/00000000-0000-0000-0000-000000000000/feature-configs/simplebool?cluster=1":
+          return makeMockSingleBoolFlagResponse(200, "simplebool", "off", version.get());
+        default:
+          throw new UnsupportedOperationException(
+              "ERROR: url not mapped " + recordedRequest.getPath());
+      }
+    }
+  }
+
+  @Test
+  void streamPatchTest() throws Exception {
+    BaseConfig config =
+        BaseConfig.builder()
+            .pollIntervalInSeconds(1)
+            .analyticsEnabled(false)
+            .streamEnabled(true)
+            .build();
+
+    try (MockWebServer mockSvr = new MockWebServer()) {
+      mockSvr.setDispatcher(new TestWebServerDispatcher());
+      mockSvr.start();
+
+      try (CfClient client =
+          new CfClient(makeConnector(mockSvr.getHostName(), mockSvr.getPort()), config)) {
+        final CountDownLatch latch = new CountDownLatch(2);
+
+        client.on(
+            Event.CHANGED,
+            e -> {
+              System.out.println("GOT EVENT -----> " + e);
+
+              if ("simplebool".equals(e)) {
+                latch.countDown();
+              }
+            });
+
+        final boolean success = latch.await(30, TimeUnit.SECONDS);
+        assertTrue(success, "Missed 1 or more patch events for flag simplebool!");
+      }
+    }
+  }
+
+  private static void onEvent(String e) {
+    if ("simplebool".equals(e)) {
+      onEventCounter.incrementAndGet();
+    }
+  }
+
+  @Test
+  void testOnOffUpdate() throws Exception {
+    BaseConfig config =
+        BaseConfig.builder()
+            .pollIntervalInSeconds(1)
+            .analyticsEnabled(false)
+            .streamEnabled(false)
+            .build();
+
+    try (final CfClient client = new CfClient(new DummyConnector(), config)) {
+      onEventCounter.set(0);
+      client.on(Event.CHANGED, CfClientTest::onEvent);
+      client.getInnerClient().notifyConsumers(Event.CHANGED, "simplebool");
+      client.getInnerClient().notifyConsumers(Event.CHANGED, "simplebool");
+      client.off();
+      client.getInnerClient().notifyConsumers(Event.CHANGED, "simplebool");
+      assertEquals(2, onEventCounter.get());
+
+      onEventCounter.set(0);
+      client.on(Event.CHANGED, CfClientTest::onEvent);
+      client.getInnerClient().notifyConsumers(Event.CHANGED, "simplebool");
+      client.getInnerClient().notifyConsumers(Event.CHANGED, "simplebool");
+      client.off(Event.CHANGED);
+      client.getInnerClient().notifyConsumers(Event.CHANGED, "simplebool");
+      assertEquals(2, onEventCounter.get());
+    }
+  }
+
+  static class DummyCache implements Cache {
+
+    @Override
+    public void set(@NonNull String key, @NonNull Object value) {}
+
+    @Override
+    public Object get(@NonNull String key) {
+      return null;
+    }
+
+    @Override
+    public void delete(@NonNull String key) {}
+
+    @Override
+    public List<String> keys() {
+      return null;
+    }
+  }
+
+  static class DummyConnector implements Connector {
+
+    @Override
+    public String authenticate() throws ConnectorException {
+      return "dummy";
+    }
+
+    @Override
+    public void setOnUnauthorized(Runnable runnable) {}
+
+    @Override
+    public List<FeatureConfig> getFlags() throws ConnectorException {
+      return Collections.emptyList();
+    }
+
+    @Override
+    public FeatureConfig getFlag(@NonNull String identifier) throws ConnectorException {
+      return null;
+    }
+
+    @Override
+    public List<Segment> getSegments() throws ConnectorException {
+      return Collections.emptyList();
+    }
+
+    @Override
+    public Segment getSegment(@NonNull String identifier) throws ConnectorException {
+      return null;
+    }
+
+    @Override
+    public void postMetrics(Metrics metrics) throws ConnectorException {}
+
+    @Override
+    public Service stream(Updater updater) throws ConnectorException {
+      return null;
+    }
+
+    @Override
+    public void close() {}
+  }
+}

--- a/src/test/java/io/harness/cf/client/api/EvaluatorTest.java
+++ b/src/test/java/io/harness/cf/client/api/EvaluatorTest.java
@@ -1,6 +1,7 @@
 package io.harness.cf.client.api;
 
 import static io.harness.cf.client.api.Operators.*;
+import static io.harness.cf.client.api.TestUtils.getJsonResource;
 import static io.harness.cf.model.FeatureConfig.KindEnum.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
@@ -14,9 +15,6 @@ import io.harness.cf.client.dto.Target;
 import io.harness.cf.model.*;
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.*;
 import java.util.concurrent.*;
 import lombok.extern.slf4j.Slf4j;
@@ -266,11 +264,6 @@ public class EvaluatorTest {
     for (final Exception e : failures) {
       fail("Failure", e);
     }
-  }
-
-  private String getJsonResource(String location) throws IOException, URISyntaxException {
-    Path path = Paths.get(EvaluatorTest.class.getClassLoader().getResource(location).toURI());
-    return new String(Files.readAllBytes(path));
   }
 
   private void loadSegments(StorageRepository repository, String resourceName)

--- a/src/test/java/io/harness/cf/client/api/TestUtils.java
+++ b/src/test/java/io/harness/cf/client/api/TestUtils.java
@@ -1,0 +1,126 @@
+package io.harness.cf.client.api;
+
+import com.google.gson.Gson;
+import io.harness.cf.client.connector.HarnessConfig;
+import io.harness.cf.client.connector.HarnessConnector;
+import io.harness.cf.model.*;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collections;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import okhttp3.mockwebserver.MockResponse;
+
+class TestUtils {
+
+  @Data
+  @AllArgsConstructor
+  static class Event {
+    String event, domain, identifier;
+    int version;
+  }
+
+  static MockResponse makeMockJsonResponse(int httpCode, String body) {
+    return new MockResponse()
+        .setResponseCode(httpCode)
+        .setBody(body)
+        .addHeader("Content-Type", "application/json; charset=UTF-8");
+  }
+
+  static String makeSegmentsJson() throws IOException, URISyntaxException {
+    return getJsonResource("local-test-cases/segments.json");
+  }
+
+  static String makeFeatureJson() throws IOException, URISyntaxException {
+    return getJsonResource("local-test-cases/percentage-rollout-with-zero-weights.json");
+  }
+
+  static String makeBasicFeatureJson() throws IOException, URISyntaxException {
+    return getJsonResource("local-test-cases/basic_bool_string_number_json_variations.json");
+  }
+
+  static MockResponse makeAuthResponse() {
+    return makeMockJsonResponse(200, "{\"authToken\": \"" + makeDummyJwtToken() + "\"}");
+  }
+
+  static MockResponse makeMockStreamResponse(int httpCode, Event... events) {
+
+    final StringBuilder builder = new StringBuilder();
+    Arrays.stream(events)
+        .forEach(
+            e -> builder.append("event: *\ndata: ").append(new Gson().toJson(e)).append("\n\n"));
+
+    return new MockResponse()
+        .setResponseCode(httpCode)
+        .setBody(builder.toString())
+        .addHeader("Content-Type", "text/event-stream; charset=UTF-8")
+        .addHeader("Accept-Encoding", "identity");
+  }
+
+  static MockResponse makeMockSingleBoolFlagResponse(
+      int httpCode, String flagName, String state, int version) {
+    final FeatureConfig flag = makeFlag(flagName, state, version);
+    return makeMockJsonResponse(httpCode, new Gson().toJson(flag));
+  }
+
+  static HarnessConnector makeConnector(String host, int port) {
+    final String url = String.format("http://%s:%s/api/1.0", host, port);
+    return new HarnessConnector(
+        "dummykey", HarnessConfig.builder().readTimeout(1000).configUrl(url).eventUrl(url).build());
+  }
+
+  static String makeDummyJwtToken() {
+    final String header = "{\"alg\":\"HS256\",\"typ\":\"JWT\"}";
+    final String payload =
+        "{\"environment\":\"00000000-0000-0000-0000-000000000000\","
+            + "\"environmentIdentifier\":\"Production\","
+            + "\"project\":\"00000000-0000-0000-0000-000000000000\","
+            + "\"projectIdentifier\":\"dev\","
+            + "\"accountID\":\"aaaaa_BBBBB-cccccccccc\","
+            + "\"organization\":\"00000000-0000-0000-0000-000000000000\","
+            + "\"organizationIdentifier\":\"default\","
+            + "\"clusterIdentifier\":\"1\","
+            + "\"key_type\":\"Server\"}";
+    final byte[] hmac256 = new byte[32];
+    return Base64.getEncoder().encodeToString(header.getBytes(StandardCharsets.UTF_8))
+        + "."
+        + Base64.getEncoder().encodeToString(payload.getBytes(StandardCharsets.UTF_8))
+        + "."
+        + Base64.getEncoder().encodeToString(hmac256);
+  }
+
+  static String getJsonResource(String location) throws IOException, URISyntaxException {
+    final Path path = Paths.get(EvaluatorTest.class.getClassLoader().getResource(location).toURI());
+    return new String(Files.readAllBytes(path));
+  }
+
+  static Event makeFlagPatchEvent(String identifier, int version) {
+    return new Event("patch", "flag", identifier, version);
+  }
+
+  static FeatureConfig makeFlag(String flagName, String state, int version) {
+    final FeatureConfig flag = new FeatureConfig();
+    flag.setDefaultServe(new Serve().variation("true"));
+    flag.setEnvironment("DUMMY");
+    flag.setFeature(flagName);
+    flag.setKind(FeatureConfig.KindEnum.BOOLEAN);
+    flag.setOffVariation("false");
+    flag.setPrerequisites(Collections.emptyList());
+    flag.setProject("DUMMYPROJ");
+    flag.setRules(Collections.emptyList());
+    flag.setState(FeatureState.fromValue(state));
+    flag.setVariationToTargetMap(Collections.emptyList());
+    flag.setVariations(
+        Arrays.asList(
+            new Variation("true", "true", "True", "desc"),
+            new Variation("false", "false", "False", "desc")));
+    flag.setVersion((long) version);
+    return flag;
+  }
+}

--- a/src/test/resources/local-test-cases/basic_bool_string_number_json_variations.json
+++ b/src/test/resources/local-test-cases/basic_bool_string_number_json_variations.json
@@ -1,0 +1,110 @@
+[
+  {
+    "defaultServe": {
+      "variation": "true"
+    },
+    "environment": "TEST",
+    "feature": "simplebool",
+    "kind": "boolean",
+    "offVariation": "false",
+    "prerequisites": [],
+    "project": "test",
+    "rules": [],
+    "state": "on",
+    "variationToTargetMap": null,
+    "variations": [
+      {
+        "identifier": "true",
+        "name": "True",
+        "value": "true"
+      },
+      {
+        "identifier": "false",
+        "name": "False",
+        "value": "false"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "defaultServe": {
+      "variation": "on"
+    },
+    "environment": "TEST",
+    "feature": "simplejson",
+    "kind": "json",
+    "offVariation": "off",
+    "prerequisites": [],
+    "project": "test",
+    "rules": [],
+    "state": "on",
+    "variationToTargetMap": null,
+    "variations": [
+      {
+        "identifier": "on",
+        "name": "on",
+        "value": "{\"value\": \"on\"}"
+      },
+      {
+        "identifier": "off",
+        "name": "off",
+        "value": "{\"value\": \"off\"}"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "defaultServe": {
+      "variation": "on"
+    },
+    "environment": "TEST",
+    "feature": "simplenumber",
+    "kind": "int",
+    "offVariation": "off",
+    "prerequisites": [],
+    "project": "test",
+    "rules": [],
+    "state": "on",
+    "variationToTargetMap": null,
+    "variations": [
+      {
+        "identifier": "on",
+        "name": "on",
+        "value": "1"
+      },
+      {
+        "identifier": "off",
+        "name": "off",
+        "value": "0"
+      }
+    ],
+    "version": 2
+  },
+  {
+    "defaultServe": {
+      "variation": "on"
+    },
+    "environment": "TEST",
+    "feature": "simplestring",
+    "kind": "string",
+    "offVariation": "off",
+    "prerequisites": [],
+    "project": "test",
+    "rules": [],
+    "state": "on",
+    "variationToTargetMap": null,
+    "variations": [
+      {
+        "identifier": "on",
+        "name": "on",
+        "value": "on-string"
+      },
+      {
+        "identifier": "off",
+        "name": "off",
+        "value": "off-string"
+      }
+    ],
+    "version": 2
+  }
+]


### PR DESCRIPTION
FFM-5247 - Java SDK - Improve unit test coverage (CfClient)

What
Increase unit test coverage on CfClient and related classes. Add new tests to bring some classes above 70% coverage

Why
Our coverage is low in certain areas

Testing
All tests pass in IntelliJ and on command line