### PR TITLE
FFM-5111 - Java SDK - Polls non stop if /stream endpoint returns 5xx error

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.harness.featureflags</groupId>
     <artifactId>examples</artifactId>
-    <version>1.1.9</version>
+    <version>1.1.10-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>io.harness</groupId>
             <artifactId>ff-java-server-sdk</artifactId>
-            <version>1.1.9</version>
+            <version>1.1.10-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.harness</groupId>
     <artifactId>ff-java-server-sdk</artifactId>
-    <version>1.1.9</version>
+    <version>1.1.10-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Harness Feature Flag Java Server SDK</name>
     <description>Harness Feature Flag Java Server SDK</description>

--- a/src/main/java/io/harness/cf/client/api/InnerClient.java
+++ b/src/main/java/io/harness/cf/client/api/InnerClient.java
@@ -235,9 +235,9 @@ class InnerClient
       pollerStartedAt = new Date();
     } else {
       log.warn(
-          "Poller was not restarted [closing={} terminated={} pollStartTime+interval={} now={} ]",
+          "Poller was not restarted [closing={} state={} pollStartTime+interval={} now={} ]",
           closing,
-          pollProcessor.state() == Service.State.TERMINATED,
+          pollProcessor.state(),
           instant,
           now);
     }
@@ -395,5 +395,9 @@ class InnerClient
 
   BaseConfig getOptions() {
     return options;
+  }
+
+  PollingProcessor getPollProcessor() {
+    return pollProcessor;
   }
 }

--- a/src/main/java/io/harness/cf/client/connector/EventSource.java
+++ b/src/main/java/io/harness/cf/client/connector/EventSource.java
@@ -110,11 +110,18 @@ public class EventSource implements ServerSentEvent.Listener, AutoCloseable, Ser
         throwable.getClass().getSimpleName(),
         throwable.getMessage());
     log.trace("onRetryError exception", throwable);
+
     updater.onError();
     if (response != null) {
-      return response.code() == 429 || response.code() >= 500;
+      return shouldRetryForHttpErrorCode(response.code());
     }
     return true;
+  }
+
+  private boolean shouldRetryForHttpErrorCode(int httpCode) {
+    if (httpCode == 501) return false;
+
+    return httpCode == 429 || httpCode >= 500;
   }
 
   @Override

--- a/src/test/java/io/harness/cf/client/api/TestUtils.java
+++ b/src/test/java/io/harness/cf/client/api/TestUtils.java
@@ -1,126 +1,35 @@
 package io.harness.cf.client.api;
 
-import com.google.gson.Gson;
 import io.harness.cf.client.connector.HarnessConfig;
 import io.harness.cf.client.connector.HarnessConnector;
-import io.harness.cf.model.*;
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.Base64;
-import java.util.Collections;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import okhttp3.mockwebserver.MockResponse;
 
-class TestUtils {
+public class TestUtils {
 
-  @Data
-  @AllArgsConstructor
-  static class Event {
-    String event, domain, identifier;
-    int version;
-  }
-
-  static MockResponse makeMockJsonResponse(int httpCode, String body) {
-    return new MockResponse()
-        .setResponseCode(httpCode)
-        .setBody(body)
-        .addHeader("Content-Type", "application/json; charset=UTF-8");
-  }
-
-  static String makeSegmentsJson() throws IOException, URISyntaxException {
+  public static String makeSegmentsJson() throws IOException, URISyntaxException {
     return getJsonResource("local-test-cases/segments.json");
   }
 
-  static String makeFeatureJson() throws IOException, URISyntaxException {
+  public static String makeFeatureJson() throws IOException, URISyntaxException {
     return getJsonResource("local-test-cases/percentage-rollout-with-zero-weights.json");
   }
 
-  static String makeBasicFeatureJson() throws IOException, URISyntaxException {
+  public static String makeBasicFeatureJson() throws IOException, URISyntaxException {
     return getJsonResource("local-test-cases/basic_bool_string_number_json_variations.json");
   }
 
-  static MockResponse makeAuthResponse() {
-    return makeMockJsonResponse(200, "{\"authToken\": \"" + makeDummyJwtToken() + "\"}");
-  }
-
-  static MockResponse makeMockStreamResponse(int httpCode, Event... events) {
-
-    final StringBuilder builder = new StringBuilder();
-    Arrays.stream(events)
-        .forEach(
-            e -> builder.append("event: *\ndata: ").append(new Gson().toJson(e)).append("\n\n"));
-
-    return new MockResponse()
-        .setResponseCode(httpCode)
-        .setBody(builder.toString())
-        .addHeader("Content-Type", "text/event-stream; charset=UTF-8")
-        .addHeader("Accept-Encoding", "identity");
-  }
-
-  static MockResponse makeMockSingleBoolFlagResponse(
-      int httpCode, String flagName, String state, int version) {
-    final FeatureConfig flag = makeFlag(flagName, state, version);
-    return makeMockJsonResponse(httpCode, new Gson().toJson(flag));
-  }
-
-  static HarnessConnector makeConnector(String host, int port) {
+  public static HarnessConnector makeConnector(String host, int port) {
     final String url = String.format("http://%s:%s/api/1.0", host, port);
     return new HarnessConnector(
         "dummykey", HarnessConfig.builder().readTimeout(1000).configUrl(url).eventUrl(url).build());
   }
 
-  static String makeDummyJwtToken() {
-    final String header = "{\"alg\":\"HS256\",\"typ\":\"JWT\"}";
-    final String payload =
-        "{\"environment\":\"00000000-0000-0000-0000-000000000000\","
-            + "\"environmentIdentifier\":\"Production\","
-            + "\"project\":\"00000000-0000-0000-0000-000000000000\","
-            + "\"projectIdentifier\":\"dev\","
-            + "\"accountID\":\"aaaaa_BBBBB-cccccccccc\","
-            + "\"organization\":\"00000000-0000-0000-0000-000000000000\","
-            + "\"organizationIdentifier\":\"default\","
-            + "\"clusterIdentifier\":\"1\","
-            + "\"key_type\":\"Server\"}";
-    final byte[] hmac256 = new byte[32];
-    return Base64.getEncoder().encodeToString(header.getBytes(StandardCharsets.UTF_8))
-        + "."
-        + Base64.getEncoder().encodeToString(payload.getBytes(StandardCharsets.UTF_8))
-        + "."
-        + Base64.getEncoder().encodeToString(hmac256);
-  }
-
-  static String getJsonResource(String location) throws IOException, URISyntaxException {
+  public static String getJsonResource(String location) throws IOException, URISyntaxException {
     final Path path = Paths.get(EvaluatorTest.class.getClassLoader().getResource(location).toURI());
     return new String(Files.readAllBytes(path));
-  }
-
-  static Event makeFlagPatchEvent(String identifier, int version) {
-    return new Event("patch", "flag", identifier, version);
-  }
-
-  static FeatureConfig makeFlag(String flagName, String state, int version) {
-    final FeatureConfig flag = new FeatureConfig();
-    flag.setDefaultServe(new Serve().variation("true"));
-    flag.setEnvironment("DUMMY");
-    flag.setFeature(flagName);
-    flag.setKind(FeatureConfig.KindEnum.BOOLEAN);
-    flag.setOffVariation("false");
-    flag.setPrerequisites(Collections.emptyList());
-    flag.setProject("DUMMYPROJ");
-    flag.setRules(Collections.emptyList());
-    flag.setState(FeatureState.fromValue(state));
-    flag.setVariationToTargetMap(Collections.emptyList());
-    flag.setVariations(
-        Arrays.asList(
-            new Variation("true", "true", "True", "desc"),
-            new Variation("false", "false", "False", "desc")));
-    flag.setVersion((long) version);
-    return flag;
   }
 }

--- a/src/test/java/io/harness/cf/client/api/dispatchers/CannedResponses.java
+++ b/src/test/java/io/harness/cf/client/api/dispatchers/CannedResponses.java
@@ -1,0 +1,103 @@
+package io.harness.cf.client.api.dispatchers;
+
+import com.google.gson.Gson;
+import io.harness.cf.model.FeatureConfig;
+import io.harness.cf.model.FeatureState;
+import io.harness.cf.model.Serve;
+import io.harness.cf.model.Variation;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collections;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import okhttp3.mockwebserver.MockResponse;
+
+public class CannedResponses {
+
+  @Data
+  @AllArgsConstructor
+  static class Event {
+    String event, domain, identifier;
+    int version;
+  }
+
+  public static MockResponse makeMockJsonResponse(int httpCode, String body) {
+    return new MockResponse()
+        .setResponseCode(httpCode)
+        .setBody(body)
+        .addHeader("Content-Type", "application/json; charset=UTF-8");
+  }
+
+  public static MockResponse makeAuthResponse() {
+    return makeMockJsonResponse(200, "{\"authToken\": \"" + makeDummyJwtToken() + "\"}");
+  }
+
+  public static MockResponse makeMockStreamResponse(int httpCode, Event... events) {
+
+    final StringBuilder builder = new StringBuilder();
+    Arrays.stream(events)
+        .forEach(
+            e -> builder.append("event: *\ndata: ").append(new Gson().toJson(e)).append("\n\n"));
+
+    return new MockResponse()
+        .setResponseCode(httpCode)
+        .setBody(builder.toString())
+        .addHeader("Content-Type", "text/event-stream; charset=UTF-8")
+        .addHeader("Accept-Encoding", "identity");
+  }
+
+  public static MockResponse makeMockEmptyJsonResponse(int httpCode) {
+    return new MockResponse().setResponseCode(httpCode);
+  }
+
+  public static MockResponse makeMockSingleBoolFlagResponse(
+      int httpCode, String flagName, String state, int version) {
+    final FeatureConfig flag = makeFlag(flagName, state, version);
+    return makeMockJsonResponse(httpCode, new Gson().toJson(flag));
+  }
+
+  public static CannedResponses.Event makeFlagPatchEvent(String identifier, int version) {
+    return new CannedResponses.Event("patch", "flag", identifier, version);
+  }
+
+  public static String makeDummyJwtToken() {
+    final String header = "{\"alg\":\"HS256\",\"typ\":\"JWT\"}";
+    final String payload =
+        "{\"environment\":\"00000000-0000-0000-0000-000000000000\","
+            + "\"environmentIdentifier\":\"Production\","
+            + "\"project\":\"00000000-0000-0000-0000-000000000000\","
+            + "\"projectIdentifier\":\"dev\","
+            + "\"accountID\":\"aaaaa_BBBBB-cccccccccc\","
+            + "\"organization\":\"00000000-0000-0000-0000-000000000000\","
+            + "\"organizationIdentifier\":\"default\","
+            + "\"clusterIdentifier\":\"1\","
+            + "\"key_type\":\"Server\"}";
+    final byte[] hmac256 = new byte[32];
+    return Base64.getEncoder().encodeToString(header.getBytes(StandardCharsets.UTF_8))
+        + "."
+        + Base64.getEncoder().encodeToString(payload.getBytes(StandardCharsets.UTF_8))
+        + "."
+        + Base64.getEncoder().encodeToString(hmac256);
+  }
+
+  public static FeatureConfig makeFlag(String flagName, String state, int version) {
+    final FeatureConfig flag = new FeatureConfig();
+    flag.setDefaultServe(new Serve().variation("true"));
+    flag.setEnvironment("DUMMY");
+    flag.setFeature(flagName);
+    flag.setKind(FeatureConfig.KindEnum.BOOLEAN);
+    flag.setOffVariation("false");
+    flag.setPrerequisites(Collections.emptyList());
+    flag.setProject("DUMMYPROJ");
+    flag.setRules(Collections.emptyList());
+    flag.setState(FeatureState.fromValue(state));
+    flag.setVariationToTargetMap(Collections.emptyList());
+    flag.setVariations(
+        Arrays.asList(
+            new Variation("true", "true", "True", "desc"),
+            new Variation("false", "false", "False", "desc")));
+    flag.setVersion((long) version);
+    return flag;
+  }
+}

--- a/src/test/java/io/harness/cf/client/api/dispatchers/TestWebServerDispatcher.java
+++ b/src/test/java/io/harness/cf/client/api/dispatchers/TestWebServerDispatcher.java
@@ -1,0 +1,42 @@
+package io.harness.cf.client.api.dispatchers;
+
+import static io.harness.cf.client.api.TestUtils.makeBasicFeatureJson;
+import static io.harness.cf.client.api.TestUtils.makeSegmentsJson;
+import static io.harness.cf.client.api.dispatchers.CannedResponses.*;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.SneakyThrows;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.jetbrains.annotations.NotNull;
+
+public class TestWebServerDispatcher extends Dispatcher {
+  private final AtomicInteger version = new AtomicInteger(2);
+
+  @Override
+  @SneakyThrows
+  @NotNull
+  public MockResponse dispatch(@NotNull RecordedRequest recordedRequest)
+      throws InterruptedException {
+    System.out.println("DISPATCH GOT ------> " + recordedRequest.getPath());
+
+    switch (Objects.requireNonNull(recordedRequest.getPath())) {
+      case "/api/1.0/client/auth":
+        return makeAuthResponse();
+      case "/api/1.0/client/env/00000000-0000-0000-0000-000000000000/feature-configs?cluster=1":
+        return makeMockJsonResponse(200, makeBasicFeatureJson());
+      case "/api/1.0/client/env/00000000-0000-0000-0000-000000000000/target-segments?cluster=1":
+        return makeMockJsonResponse(200, makeSegmentsJson());
+      case "/api/1.0/stream?cluster=1":
+        return makeMockStreamResponse(
+            200, makeFlagPatchEvent("simplebool", version.getAndIncrement()));
+      case "/api/1.0/client/env/00000000-0000-0000-0000-000000000000/feature-configs/simplebool?cluster=1":
+        return makeMockSingleBoolFlagResponse(200, "simplebool", "off", version.get());
+      default:
+        throw new UnsupportedOperationException(
+            "ERROR: url not mapped " + recordedRequest.getPath());
+    }
+  }
+}

--- a/src/test/java/io/harness/cf/client/api/dispatchers/UnimplementedStreamDispatcher.java
+++ b/src/test/java/io/harness/cf/client/api/dispatchers/UnimplementedStreamDispatcher.java
@@ -1,0 +1,58 @@
+package io.harness.cf.client.api.dispatchers;
+
+import static io.harness.cf.client.api.dispatchers.CannedResponses.makeMockEmptyJsonResponse;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.Getter;
+import lombok.SneakyThrows;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.jetbrains.annotations.NotNull;
+
+public class UnimplementedStreamDispatcher extends TestWebServerDispatcher {
+
+  private static final String STREAM_ENDPOINT = "/api/1.0/stream?cluster=1";
+  @Getter private final AtomicInteger streamEndpointCount = new AtomicInteger(0);
+  private final int maxConnectionAttempts;
+
+  public UnimplementedStreamDispatcher(int maxConnectionAttempts) {
+    this.maxConnectionAttempts = maxConnectionAttempts;
+  }
+
+  @Override
+  @SneakyThrows
+  @NotNull
+  public MockResponse dispatch(@NotNull RecordedRequest recordedRequest) {
+    if (STREAM_ENDPOINT.equals(recordedRequest.getPath())) {
+      System.out.println("Returning 501 for stream endpoint");
+      streamEndpointCount.incrementAndGet();
+      return makeMockEmptyJsonResponse(501); // return 501 unimplemented on /api/1.0/stream
+    }
+    return super.dispatch(recordedRequest);
+  }
+
+  public void waitForAllConnections(int waitTimeSeconds) throws InterruptedException {
+    final int delayMs = 100;
+    int maxWaitTime = (waitTimeSeconds * 1000) / delayMs;
+    while (maxWaitTime > 0) {
+      if (streamEndpointCount.get() > maxConnectionAttempts) {
+        fail(
+            "Too many connection attempts to "
+                + STREAM_ENDPOINT
+                + " = "
+                + streamEndpointCount.get());
+      }
+
+      System.out.printf(
+          "Waiting for connections: got %d of %d...\n",
+          streamEndpointCount.get(), maxConnectionAttempts);
+      Thread.sleep(delayMs);
+      maxWaitTime--;
+    }
+
+    if (streamEndpointCount.get() == 0) {
+      fail("Did not get any connection attempts to " + STREAM_ENDPOINT);
+    }
+  }
+}


### PR DESCRIPTION
FFM-5111 - Java SDK - Polls non stop if /stream endpoint returns 5xx error

What
If a /stream endpoint returns a 501 HTTP error code (unimplemented) then the SSE library attempts reconnect endlessly

Why
The code is assuming 501 is a transient http error - so keeps retrying it rather than backing off for good

Testing
Added new mock web server dispatcher to mimic a 501 response when /stream is connected to. New assertion were added to ensure SDK doesn't attempt to reconnect once when a 501 is returned.

[FFM-5111]: https://harness.atlassian.net/browse/FFM-5111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ