### PR TITLE
FFM-6442 - Java SDK - java.lang.IllegalStateException logged by okhttp

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The first step is to install the FF SDK as a dependency in your application usin
 
 Refer to the [Harness Feature Flag Java Server SDK](https://mvnrepository.com/artifact/io.harness/ff-java-server-sdk) to identify the latest version for your build automation tool.
 
-This section lists dependencies for Maven and Gradle and uses the 1.1.9 version as an example:
+This section lists dependencies for Maven and Gradle and uses the 1.1.10 version as an example:
 
 #### Maven
 
@@ -78,14 +78,14 @@ Add the following Maven dependency in your project's pom.xml file:
 <dependency>
     <groupId>io.harness</groupId>
     <artifactId>ff-java-server-sdk</artifactId>
-    <version>1.1.9</version>
+    <version>1.1.10</version>
 </dependency>
 ```
 
 #### Gradle
 
 ```
-implementation group: 'io.harness', name: 'ff-java-server-sdk', version: '1.1.9'
+implementation group: 'io.harness', name: 'ff-java-server-sdk', version: '1.1.10'
 ```
 
 ### Code Sample

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.harness.featureflags</groupId>
     <artifactId>examples</artifactId>
-    <version>1.1.10-SNAPSHOT</version>
+    <version>1.1.10</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>io.harness</groupId>
             <artifactId>ff-java-server-sdk</artifactId>
-            <version>1.1.10-SNAPSHOT</version>
+            <version>1.1.10</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.harness</groupId>
     <artifactId>ff-java-server-sdk</artifactId>
-    <version>1.1.10-SNAPSHOT</version>
+    <version>1.1.10</version>
     <packaging>jar</packaging>
     <name>Harness Feature Flag Java Server SDK</name>
     <description>Harness Feature Flag Java Server SDK</description>

--- a/src/main/java/io/harness/cf/client/api/PollingProcessor.java
+++ b/src/main/java/io/harness/cf/client/api/PollingProcessor.java
@@ -72,7 +72,7 @@ class PollingProcessor extends AbstractScheduledService {
       completableFuture.complete(segments);
     } catch (ConnectorException e) {
       log.error(
-          "Exception was raised when fetching flags data with the message {}", e.getMessage());
+          "Exception was raised when fetching flags data with the message {}", e.getMessage(), e);
       completableFuture.completeExceptionally(e);
     }
     return completableFuture;

--- a/src/main/java/io/harness/cf/client/connector/ConnectorException.java
+++ b/src/main/java/io/harness/cf/client/connector/ConnectorException.java
@@ -1,7 +1,26 @@
 package io.harness.cf.client.connector;
 
 public class ConnectorException extends Exception {
+
+  private final int httpCode;
+  private final String httpReason;
+
   public ConnectorException(String message) {
     super(message);
+    this.httpCode = 0;
+    this.httpReason = "";
+  }
+
+  public ConnectorException(String message, int httpCode, String httpMsg) {
+    super(message);
+    this.httpCode = httpCode;
+    this.httpReason = httpMsg;
+  }
+
+  @Override
+  public String getMessage() {
+    final String httpInfo =
+        (httpCode == 0) ? "" : String.format(" - httpCode=%d httpReason=%s", httpCode, httpReason);
+    return super.getMessage() + httpInfo;
   }
 }

--- a/src/main/java/io/harness/cf/client/connector/RetryInterceptor.java
+++ b/src/main/java/io/harness/cf/client/connector/RetryInterceptor.java
@@ -24,6 +24,8 @@ class RetryInterceptor implements Interceptor {
     while (!response.isSuccessful() && tryCount < maxTryCount) {
       log.debug("Request is not successful - {}", tryCount);
 
+      response.close();
+
       tryCount++;
 
       try {

--- a/src/test/java/io/harness/cf/client/api/TestUtils.java
+++ b/src/test/java/io/harness/cf/client/api/TestUtils.java
@@ -1,7 +1,5 @@
 package io.harness.cf.client.api;
 
-import io.harness.cf.client.connector.HarnessConfig;
-import io.harness.cf.client.connector.HarnessConnector;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
@@ -20,12 +18,6 @@ public class TestUtils {
 
   public static String makeBasicFeatureJson() throws IOException, URISyntaxException {
     return getJsonResource("local-test-cases/basic_bool_string_number_json_variations.json");
-  }
-
-  public static HarnessConnector makeConnector(String host, int port) {
-    final String url = String.format("http://%s:%s/api/1.0", host, port);
-    return new HarnessConnector(
-        "dummykey", HarnessConfig.builder().readTimeout(1000).configUrl(url).eventUrl(url).build());
   }
 
   public static String getJsonResource(String location) throws IOException, URISyntaxException {

--- a/src/test/java/io/harness/cf/client/api/dispatchers/CannedResponses.java
+++ b/src/test/java/io/harness/cf/client/api/dispatchers/CannedResponses.java
@@ -1,5 +1,7 @@
 package io.harness.cf.client.api.dispatchers;
 
+import static java.lang.String.format;
+
 import com.google.gson.Gson;
 import io.harness.cf.model.FeatureConfig;
 import io.harness.cf.model.FeatureState;
@@ -30,7 +32,11 @@ public class CannedResponses {
   }
 
   public static MockResponse makeAuthResponse() {
-    return makeMockJsonResponse(200, "{\"authToken\": \"" + makeDummyJwtToken() + "\"}");
+    return makeAuthResponse(200);
+  }
+
+  public static MockResponse makeAuthResponse(int httpCode) {
+    return makeMockJsonResponse(httpCode, "{\"authToken\": \"" + makeDummyJwtToken() + "\"}");
   }
 
   public static MockResponse makeMockStreamResponse(int httpCode, Event... events) {
@@ -49,6 +55,10 @@ public class CannedResponses {
 
   public static MockResponse makeMockEmptyJsonResponse(int httpCode) {
     return new MockResponse().setResponseCode(httpCode);
+  }
+
+  public static MockResponse makeMockEmptyJsonResponse(int httpCode, String httpReason) {
+    return new MockResponse().setStatus(format("HTTP/1.1 %d %s", httpCode, httpReason));
   }
 
   public static MockResponse makeMockSingleBoolFlagResponse(

--- a/src/test/java/io/harness/cf/client/api/dispatchers/Endpoints.java
+++ b/src/test/java/io/harness/cf/client/api/dispatchers/Endpoints.java
@@ -1,0 +1,13 @@
+package io.harness.cf.client.api.dispatchers;
+
+public class Endpoints {
+
+  static final String AUTH_ENDPOINT = "/api/1.0/client/auth";
+  static final String FEATURES_ENDPOINT =
+      "/api/1.0/client/env/00000000-0000-0000-0000-000000000000/feature-configs?cluster=1";
+  static final String SEGMENTS_ENDPOINT =
+      "/api/1.0/client/env/00000000-0000-0000-0000-000000000000/target-segments?cluster=1";
+  static final String STREAM_ENDPOINT = "/api/1.0/stream?cluster=1";
+  static final String SIMPLE_BOOL_FLAG_ENDPOINT =
+      "/api/1.0/client/env/00000000-0000-0000-0000-000000000000/feature-configs/simplebool?cluster=1";
+}

--- a/src/test/java/io/harness/cf/client/api/dispatchers/Http4xxOnFirstAuthDispatcher.java
+++ b/src/test/java/io/harness/cf/client/api/dispatchers/Http4xxOnFirstAuthDispatcher.java
@@ -1,0 +1,64 @@
+package io.harness.cf.client.api.dispatchers;
+
+import static io.harness.cf.client.api.TestUtils.makeBasicFeatureJson;
+import static io.harness.cf.client.api.TestUtils.makeSegmentsJson;
+import static io.harness.cf.client.api.dispatchers.CannedResponses.*;
+import static io.harness.cf.client.api.dispatchers.Endpoints.*;
+
+import io.harness.cf.client.api.testutils.PollingAtomicLong;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.Getter;
+import lombok.SneakyThrows;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.jetbrains.annotations.NotNull;
+
+public class Http4xxOnFirstAuthDispatcher extends TestWebServerDispatcher {
+  private final AtomicInteger version = new AtomicInteger(2);
+  @Getter private final PollingAtomicLong authAttempts;
+
+  public Http4xxOnFirstAuthDispatcher(int minAuthAttempts) {
+    authAttempts = new PollingAtomicLong(minAuthAttempts);
+  }
+
+  private MockResponse dispatchAuthResp() {
+    System.out.println("DISPATCH authAttempts = " + authAttempts.get());
+
+    if (authAttempts.getAndIncrement() < 6) {
+      return makeAuthResponse(403);
+    }
+    return makeAuthResponse(200);
+  }
+
+  @Override
+  @SneakyThrows
+  @NotNull
+  public MockResponse dispatch(@NotNull RecordedRequest recordedRequest) {
+    System.out.println("DISPATCH GOT ------> " + recordedRequest.getPath());
+
+    switch (Objects.requireNonNull(recordedRequest.getPath())) {
+      case AUTH_ENDPOINT:
+        return dispatchAuthResp();
+      case FEATURES_ENDPOINT:
+        return makeMockJsonResponse(200, makeBasicFeatureJson());
+      case SEGMENTS_ENDPOINT:
+        return makeMockJsonResponse(200, makeSegmentsJson());
+      case STREAM_ENDPOINT:
+        return makeMockStreamResponse(
+            200, makeFlagPatchEvent("simplebool", version.getAndIncrement()));
+      case SIMPLE_BOOL_FLAG_ENDPOINT:
+        return makeMockSingleBoolFlagResponse(200, "simplebool", "off", version.get());
+      default:
+        throw new UnsupportedOperationException(
+            "ERROR: url not mapped " + recordedRequest.getPath());
+    }
+  }
+
+  public void waitForAllConnections(int waitTimeSeconds) throws InterruptedException {
+    authAttempts.waitForMinimumValueToBeReached(
+        waitTimeSeconds,
+        "auth",
+        "Did not get minimum number of auth connection attempts to " + AUTH_ENDPOINT);
+  }
+}

--- a/src/test/java/io/harness/cf/client/api/dispatchers/Http4xxOnGetAllSegmentsDispatcher.java
+++ b/src/test/java/io/harness/cf/client/api/dispatchers/Http4xxOnGetAllSegmentsDispatcher.java
@@ -1,0 +1,83 @@
+package io.harness.cf.client.api.dispatchers;
+
+import static io.harness.cf.client.api.TestUtils.makeBasicFeatureJson;
+import static io.harness.cf.client.api.TestUtils.makeSegmentsJson;
+import static io.harness.cf.client.api.dispatchers.CannedResponses.*;
+import static io.harness.cf.client.api.dispatchers.Endpoints.*;
+
+import io.harness.cf.client.api.testutils.PollingAtomicLong;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.Getter;
+import lombok.SneakyThrows;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.jetbrains.annotations.NotNull;
+
+public class Http4xxOnGetAllSegmentsDispatcher extends TestWebServerDispatcher {
+  private final AtomicInteger version = new AtomicInteger(2);
+  @Getter private final PollingAtomicLong authAttempts;
+  @Getter private final PollingAtomicLong getSegmentsAttempts;
+
+  public Http4xxOnGetAllSegmentsDispatcher(int minAuthAttempts, int minGetSegmentsAttempts) {
+    authAttempts = new PollingAtomicLong(minAuthAttempts);
+    getSegmentsAttempts = new PollingAtomicLong(minGetSegmentsAttempts);
+  }
+
+  private MockResponse makeSegmentsResp() throws IOException, URISyntaxException {
+    System.out.println("getSegmentsAttempts " + getSegmentsAttempts.get());
+
+    final long reqNo = getSegmentsAttempts.getAndIncrement();
+
+    if (reqNo == 0) {
+      return makeMockJsonResponse(200, makeSegmentsJson()); // 1st will succeed
+    } else if (reqNo >= 1 && reqNo <= 4) {
+      return makeMockEmptyJsonResponse(
+          403,
+          "Forbidden - reqNo "
+              + reqNo); // Fail 2nd-4th request to bypass retries and trigger re-auth
+    } else {
+      return makeMockJsonResponse(
+          200, makeSegmentsJson()); // 5th and subsequent requests will return 200s
+    }
+  }
+
+  @Override
+  @SneakyThrows
+  @NotNull
+  public MockResponse dispatch(@NotNull RecordedRequest recordedRequest) {
+    System.out.println("DISPATCH GOT ------> " + recordedRequest.getPath());
+
+    switch (Objects.requireNonNull(recordedRequest.getPath())) {
+      case AUTH_ENDPOINT:
+        authAttempts.getAndIncrement();
+        return makeAuthResponse(200);
+      case FEATURES_ENDPOINT:
+        return makeMockJsonResponse(200, makeBasicFeatureJson());
+      case SEGMENTS_ENDPOINT:
+        return makeSegmentsResp();
+      case STREAM_ENDPOINT:
+        return makeMockStreamResponse(
+            200, makeFlagPatchEvent("simplebool", version.getAndIncrement()));
+      case SIMPLE_BOOL_FLAG_ENDPOINT:
+        return makeMockSingleBoolFlagResponse(200, "simplebool", "off", version.get());
+      default:
+        throw new UnsupportedOperationException(
+            "ERROR: url not mapped " + recordedRequest.getPath());
+    }
+  }
+
+  public void waitForAllConnections(int waitTimeSeconds) throws InterruptedException {
+    authAttempts.waitForMinimumValueToBeReached(
+        waitTimeSeconds,
+        "auth",
+        "Did not get minimum number of auth connection attempts to " + AUTH_ENDPOINT);
+    getSegmentsAttempts.waitForMinimumValueToBeReached(
+        waitTimeSeconds,
+        "target-segments",
+        "Did not get minimum number of target-segments connection attempts to "
+            + SEGMENTS_ENDPOINT);
+  }
+}

--- a/src/test/java/io/harness/cf/client/api/testutils/PollingAtomicLong.java
+++ b/src/test/java/io/harness/cf/client/api/testutils/PollingAtomicLong.java
@@ -1,0 +1,30 @@
+package io.harness.cf.client.api.testutils;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+public class PollingAtomicLong extends AtomicLong {
+  private final int minValueToWaitFor;
+
+  public PollingAtomicLong(int minValueToWaitFor) {
+    this.minValueToWaitFor = minValueToWaitFor;
+  }
+
+  public void waitForMinimumValueToBeReached(int waitTimeSeconds, String name, String failMsg)
+      throws InterruptedException {
+    final int delayMs = 100;
+    int maxWaitTime = (waitTimeSeconds * 1000) / delayMs;
+    while (maxWaitTime > 0 && get() < minValueToWaitFor) {
+
+      System.out.printf(
+          "Waiting for " + name + " connections: got %d of min %d...\n", get(), minValueToWaitFor);
+      Thread.sleep(delayMs);
+      maxWaitTime--;
+    }
+
+    if (get() < minValueToWaitFor) {
+      fail(failMsg);
+    }
+  }
+}

--- a/src/test/java/io/harness/cf/client/connector/HarnessConnectorUtils.java
+++ b/src/test/java/io/harness/cf/client/connector/HarnessConnectorUtils.java
@@ -1,0 +1,22 @@
+package io.harness.cf.client.connector;
+
+
+public class HarnessConnectorUtils {
+  public static HarnessConnector makeConnector(String host, int port) {
+    final String url = String.format("http://%s:%s/api/1.0", host, port);
+    return new HarnessConnector(
+        "dummykey", HarnessConfig.builder().readTimeout(1000).configUrl(url).eventUrl(url).build());
+  }
+
+  /**
+   * This uses an internal constructor to create a connector with a reduced retry timeout (50ms
+   * instead of 2000ms). This allows tests with retry logic to run faster during builds.
+   */
+  public static HarnessConnector makeConnectorWithMinimalRetryBackOff(String host, int port) {
+    final String url = String.format("http://%s:%s/api/1.0", host, port);
+    return new HarnessConnector(
+        "dummykey",
+        HarnessConfig.builder().readTimeout(1000).configUrl(url).eventUrl(url).build(),
+        50);
+  }
+}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -8,8 +8,9 @@
             </pattern>
         </encoder>
     </appender>
-    <logger name="io.harness.cf.client" level="DEBUG"/>
-    <logger name="io.harness.cf.client.api.MetricsProcessor" level="WARN"/>
+
+    <logger name="io.harness.cf.client" level="INFO"/>
+
     <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>


### PR DESCRIPTION
What
- Fixed RetryInterceptor to close response & remove old fix
- Fixed 403 re-authentication logic to correctly restart auth service
- Added new tests for returning and asserting 4xx codes
- ConnectionException to now stores HTTP code and reason for better logging + removed some excessive logging

Why
java.lang.IllegalStateException "cannot make a new request because the previous response is still open" is seen when the endpoint returns a 4xx error. Due to connection not being closed correctly in retry interceptor.

Testing
New unit tests added in CfClientTest for testing 4xx reponses + manual testing