### PR TITLE
Add broader exception handling in case authentication fails

### DIFF
--- a/src/main/java/io/harness/cf/client/api/AuthCallback.java
+++ b/src/main/java/io/harness/cf/client/api/AuthCallback.java
@@ -2,4 +2,6 @@ package io.harness.cf.client.api;
 
 interface AuthCallback {
   void onAuthSuccess();
+
+  void onFailure(final String message);
 }

--- a/src/main/java/io/harness/cf/client/api/AuthService.java
+++ b/src/main/java/io/harness/cf/client/api/AuthService.java
@@ -33,10 +33,16 @@ class AuthService extends AbstractScheduledService {
       stopAsync();
       log.info("Stopping Auth service");
     } catch (ConnectorException e) {
-      log.error(
-          "Exception while authenticating, retry in {} seconds, error: {}",
-          pollIntervalInSec,
-          e.getMessage());
+      if (e.shouldRetry()) {
+        log.error(
+            "Exception while authenticating, retry in {} seconds, error: {}",
+            pollIntervalInSec,
+            e.getMessage());
+      } else {
+        stopAsync();
+        log.error("Exception while authenticating", e);
+        callback.onFailure(e.getMessage());
+      }
     }
   }
 

--- a/src/main/java/io/harness/cf/client/api/InnerClient.java
+++ b/src/main/java/io/harness/cf/client/api/InnerClient.java
@@ -335,7 +335,7 @@ class InnerClient
       throws InterruptedException, FeatureFlagInitializeException {
     while (!initialized) {
       log.info("Wait for initialization to finish");
-      wait();
+      wait(5000);
 
       if (failure) {
         log.error("Failure while initializing SDK!");

--- a/src/main/java/io/harness/cf/client/connector/ConnectorException.java
+++ b/src/main/java/io/harness/cf/client/connector/ConnectorException.java
@@ -3,18 +3,33 @@ package io.harness.cf.client.connector;
 public class ConnectorException extends Exception {
 
   private final int httpCode;
+  private final boolean shouldRetry;
+
   private final String httpReason;
 
   public ConnectorException(String message) {
     super(message);
     this.httpCode = 0;
     this.httpReason = "";
+    this.shouldRetry = true;
   }
 
   public ConnectorException(String message, int httpCode, String httpMsg) {
     super(message);
     this.httpCode = httpCode;
     this.httpReason = httpMsg;
+    this.shouldRetry = true;
+  }
+  
+    public ConnectorException(String message, boolean shouldRetry, Exception e) {
+    super(message, e);
+    this.shouldRetry = shouldRetry;
+    this.httpCode = 0;
+    this.httpReason = "";
+  }
+
+  public boolean shouldRetry() {
+    return shouldRetry;
   }
 
   @Override


### PR DESCRIPTION
Also only wait for 5 seconds instead of forever, allowing the failure check to propagate and for the app to shutdown

I ran into a few issues with the SDK when I had put in the wrong apiKey. So this PR just improves that failure case