### PR TITLE
FFM-7004 - Java SDK - TLS - support custom CAs

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -65,6 +65,13 @@
             <version>2.19.0</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/org.bouncycastle/bcpkix-jdk18on -->
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk18on</artifactId>
+            <version>1.72</version>
+        </dependency>
+
     </dependencies>
 
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.harness.featureflags</groupId>
     <artifactId>examples</artifactId>
-    <version>1.1.11</version>
+    <version>1.2.0</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>io.harness</groupId>
             <artifactId>ff-java-server-sdk</artifactId>
-            <version>1.1.11</version>
+            <version>1.2.0</version>
         </dependency>
 
         <dependency>

--- a/examples/src/main/java/io/harness/ff/examples/TlsExample.java
+++ b/examples/src/main/java/io/harness/ff/examples/TlsExample.java
@@ -1,0 +1,100 @@
+package io.harness.ff.examples;
+
+import io.harness.cf.client.api.BaseConfig;
+import io.harness.cf.client.api.CfClient;
+import io.harness.cf.client.api.FeatureFlagInitializeException;
+import io.harness.cf.client.connector.HarnessConfig;
+import io.harness.cf.client.connector.HarnessConnector;
+import io.harness.cf.client.dto.Target;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openssl.PEMParser;
+
+import java.io.FileReader;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.Provider;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import static java.lang.System.out;
+
+public class TlsExample {
+    private static final String apiKey = getEnvOrDefault("FF_API_KEY", "");
+    private static final String flagName = getEnvOrDefault("FF_FLAG_NAME", "harnessappdemodarkmode");
+    private static final String trustedCaPemFile = getEnvOrDefault("FF_TRUSTED_CA_FILE_NAME", "/change/me/CA.pem");
+
+    private static final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+    private static final Provider bcProvider = new BouncyCastleProvider();
+
+
+    public static void main(String[] args) throws InterruptedException, FeatureFlagInitializeException, GeneralSecurityException, IOException {
+        out.println("Java SDK TLS example");
+
+        List<X509Certificate> trustedServers = loadCerts(trustedCaPemFile);
+
+        // Note that this code uses ffserver hostname as an example, likely you'll have your own hostname or IP.
+        // You should ensure the endpoint is returning a cert with valid SANs configured for the host/IP.
+        HarnessConfig config = HarnessConfig.builder()
+                .configUrl("https://ffserver:8001/api/1.0")
+                .eventUrl("https://ffserver:8000/api/1.0")
+                .tlsTrustedCAs(trustedServers)
+                .build();
+
+        HarnessConnector connector = new HarnessConnector(apiKey, config);
+
+        try (CfClient cfClient = new CfClient(connector)) {
+
+            cfClient.waitForInitialization();
+
+            final Target target = Target.builder()
+                    .identifier("javasdk")
+                    .name("JavaSDK")
+                    .build();
+
+            // Loop forever reporting the state of the flag
+            scheduler.scheduleAtFixedRate(
+                    () -> {
+                        boolean result = cfClient.boolVariation(flagName, target, false);
+                        out.println("Flag '" + flagName + "' Boolean variation is " + result);
+                    },
+                    0,
+                    10,
+                    TimeUnit.SECONDS);
+
+
+            TimeUnit.MINUTES.sleep(15);
+
+            out.println("Cleaning up...");
+            scheduler.shutdownNow();
+        }
+    }
+
+    // Get the value from the environment or return the default
+    private static String getEnvOrDefault(String key, String defaultValue) {
+        String value = System.getenv(key);
+        if (value == null || value.isEmpty()) {
+            return defaultValue;
+        }
+        return value;
+    }
+
+    // Here we're using BC's PKIX lib to convert the PEM to an X.509, you can use any crypto library you prefer
+    private static List<X509Certificate> loadCerts(String filename) throws IOException, CertificateException {
+        List<X509Certificate> list = new ArrayList<>();
+        try (PEMParser parser = new PEMParser(new FileReader(filename))) {
+            Object obj;
+            while ((obj = parser.readObject()) !=  null) {
+                if (obj instanceof X509CertificateHolder) {
+                    list.add(new JcaX509CertificateConverter().setProvider(bcProvider).getCertificate((X509CertificateHolder) obj));
+                }
+            }
+        }
+        return list;
+    }
+}

--- a/examples/src/main/resources/log4j.properties
+++ b/examples/src/main/resources/log4j.properties
@@ -1,2 +1,2 @@
-log4j.rootLogger=debug
-log4j.logger.io.harness=debug
+log4j.rootLogger=info
+log4j.logger.io.harness=info

--- a/examples/src/main/resources/log4j2.xml
+++ b/examples/src/main/resources/log4j2.xml
@@ -11,7 +11,7 @@
     </Appenders>
 
     <Loggers>
-        <Root level="debug">
+        <Root level="info">
             <AppenderRef ref="console"/>
         </Root>
     </Loggers>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.harness</groupId>
     <artifactId>ff-java-server-sdk</artifactId>
-    <version>1.1.11</version>
+    <version>1.2.0</version>
     <packaging>jar</packaging>
     <name>Harness Feature Flag Java Server SDK</name>
     <description>Harness Feature Flag Java Server SDK</description>

--- a/src/main/java/io/harness/cf/client/connector/HarnessConfig.java
+++ b/src/main/java/io/harness/cf/client/connector/HarnessConfig.java
@@ -1,5 +1,7 @@
 package io.harness.cf.client.connector;
 
+import java.security.cert.X509Certificate;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -25,4 +27,10 @@ public class HarnessConfig {
 
   /** read timeout in minutes for SSE connections */
   @Builder.Default long sseReadTimeout = 1;
+
+  /**
+   * list of trusted CAs - for when the given config/event URLs are signed with a private CA. You
+   * should include intermediate CAs too to allow the HTTP client to build a full trust chain.
+   */
+  @Builder.Default List<X509Certificate> tlsTrustedCAs = null;
 }

--- a/src/main/java/io/harness/cf/client/connector/HarnessConnector.java
+++ b/src/main/java/io/harness/cf/client/connector/HarnessConnector.java
@@ -326,7 +326,7 @@ public class HarnessConnector implements Connector, AutoCloseable {
   }
 
   @Override
-  public Service stream(@NonNull final Updater updater) {
+  public Service stream(@NonNull final Updater updater) throws ConnectorException {
     log.debug("Check if eventsource is already initialized");
     if (eventSource != null) {
       log.debug("EventSource is already initialized, closing ...");

--- a/src/test/java/io/harness/cf/client/connector/EventSourceTest.java
+++ b/src/test/java/io/harness/cf/client/connector/EventSourceTest.java
@@ -70,7 +70,7 @@ class EventSourceTest {
 
   @Test
   void shouldNotCallErrorHandlerIfRetryEventuallyReconnectsToStreamEndpoint()
-      throws IOException, InterruptedException {
+      throws IOException, InterruptedException, ConnectorException {
     CountingUpdater updater = new CountingUpdater();
 
     try (MockWebServer mockSvr = new MockWebServer();
@@ -98,7 +98,7 @@ class EventSourceTest {
 
   @Test
   void shouldRestartPollerIfAllConnectionAttemptsToStreamEndpointFail()
-      throws IOException, InterruptedException {
+      throws IOException, InterruptedException, ConnectorException {
     CountingUpdater updater = new CountingUpdater();
 
     try (MockWebServer mockSvr = new MockWebServer();

--- a/src/test/java/io/harness/cf/client/connector/EventSourceTest.java
+++ b/src/test/java/io/harness/cf/client/connector/EventSourceTest.java
@@ -76,7 +76,12 @@ class EventSourceTest {
     try (MockWebServer mockSvr = new MockWebServer();
         EventSource eventSource =
             new EventSource(
-                setupMockServer(mockSvr, new StreamDispatcher()), new HashMap<>(), updater, 1, 1)) {
+                setupMockServer(mockSvr, new StreamDispatcher()),
+                new HashMap<>(),
+                updater,
+                1,
+                1,
+                null)) {
       eventSource.start();
 
       TimeUnit.SECONDS.sleep(15);
@@ -103,7 +108,8 @@ class EventSourceTest {
                 new HashMap<>(),
                 updater,
                 1,
-                1)) {
+                1,
+                null)) {
       eventSource.start();
 
       TimeUnit.SECONDS.sleep(15);


### PR DESCRIPTION
FFM-7004 - Java SDK - TLS - support custom CAs

What
Allow the SDK user to provide a custom TLS CA via the HarnessConnector API

Why
We currently rely on pre-installed CA bundles in the JDK for TLS connections, e.g. those hostnames signed by public CAs, it's useful to provide alternative methods of loading private TLS CAs for internal on-prem deployments

Testing
Manual - tested against a ff-server proxy with TLS termination enabled