### PR TITLE
(FFM-7131) Add flag cleanup example

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,3 +192,6 @@ Further examples and config options are in the further reading section:
 test features quicker.
 
 -------------------------
+
+### Code Cleanup (Beta)
+The java sdk supports automated code cleanup. For more info see the [docs](/examples/src/main/java/io/harness/ff/code_cleanup_examples/README.md)

--- a/examples/src/main/java/io/harness/ff/code_cleanup_examples/README.md
+++ b/examples/src/main/java/io/harness/ff/code_cleanup_examples/README.md
@@ -1,0 +1,14 @@
+## Flag Cleanup (beta)
+The java sdk supports automated code cleanup using the Flag Cleanup drone plugin. See [here](https://github.com/harness/flag_cleanup) for detailed docs on usage of the plugin.
+
+### Run example
+1. View the [example file](/examples/src/main/java/io/harness/ff/code_cleanup_examples/SampleClass.java) and observe the if else block using our feature flag ```STALE_FLAG```
+2. Run the flag cleanup plugin from this directory. This can be done by running the following docker container
+
+```docker run -v ${PWD}:/java-sdk -e PLUGIN_DEBUG=true -e PLUGIN_PATH_TO_CODEBASE="/java-sdk" -e PLUGIN_PATH_TO_CONFIGURATIONS="/java-sdk/config" -e PLUGIN_LANGUAGE="java" -e PLUGIN_SUBSTITUTIONS="stale_flag_name=STALE_FLAG,treated=true,treated_complement=false" harness/flag_cleanup:latest```
+
+3. Observe that the `if else` block for `STALE_FLAG` has been removed from the code and the flag is now treated as globally true.
+
+
+### Further reading
+For more rules.toml examples see the test cases [here](https://github.com/uber/piranha/tree/master/test-resources/java)

--- a/examples/src/main/java/io/harness/ff/code_cleanup_examples/SampleClass.java
+++ b/examples/src/main/java/io/harness/ff/code_cleanup_examples/SampleClass.java
@@ -1,0 +1,42 @@
+package io.harness.ff.code_cleanup_examples;
+
+import io.harness.cf.client.api.*;
+import io.harness.cf.client.dto.Target;
+
+class SampleJava {
+    enum Flags {
+        STALE_FLAG,
+        OTHER_FLAG
+    }
+
+    private static final String SDK_KEY = System.getenv("SDK_KEY");
+    private static CfClient client;
+
+    public static void main(String... args) throws FeatureFlagInitializeException, InterruptedException {
+        client = new CfClient(SDK_KEY, Config.builder().store(fileStore).build());
+        client.waitForInitialization();
+
+        final Target target =
+                Target.builder()
+                        .identifier("target1")
+                        .isPrivate(false)
+                        .attribute("testKey", "TestValue")
+                        .name("target1")
+                        .build();
+
+
+        if (client.boolVariation(Flags.STALE_FLAG)) {
+            System.out.println("STALE_FLAG is true code path");
+        } else {
+            System.out.println("STALE_FLAG is false code path");
+        }
+
+        if (client.boolVariation(Flags.OTHER_FLAG)) {
+            System.out.println("OTHER_FLAG is true code path");
+        } else {
+            System.out.println("OTHER_FLAG is false code path");
+        }
+
+    }
+
+}

--- a/examples/src/main/java/io/harness/ff/code_cleanup_examples/config/rules.toml
+++ b/examples/src/main/java/io/harness/ff/code_cleanup_examples/config/rules.toml
@@ -1,0 +1,47 @@
+# Find any instance where we call the function boolVariation() with a feature flag enum value
+# e.g. where @stale_flag_name is STALE_FLAG this would match a call looking like boolVariation(myEnum.STALE_FLAG)
+# note extra params dont matter - this rule will also match boolVariation(myEnum.STALE_FLAG, "other_param", morestuff)
+[[rules]]
+name = "replace_boolVariation_with_boolean_literal"
+query = """((
+    (method_invocation
+        name : (_) @name
+        arguments: ((argument_list
+                        ([
+                          (field_access field: (_)@argument)
+                          (_) @argument
+                         ])) )
+
+    ) @method_invocation
+)
+(#eq? @name "boolVariation")
+(#eq? @argument "@stale_flag_name")
+)"""
+replace_node = "method_invocation"
+replace = "@treated"
+groups = ["replace_expression_with_boolean_literal"]
+holes = ["treated", "stale_flag_name"]
+
+# Cleanup the enum declaration itself e.g.
+# For @stale_flag_name = STALE_FLAG
+# Before :
+#  enum Flags {
+#   ABC, STALE_FLAG, OTHER_FLAG
+#  }
+# After :
+#  enum Flags {
+#   ABC, OTHER_FLAG
+#  }
+#
+[[rules]]
+name = "delete_enum_constant"
+query = """
+    (
+    ((enum_constant name : (_) @n) @ec)
+    (#eq? @n  "@stale_flag_name")
+    )
+    """
+replace_node = "ec"
+replace = ""
+holes = ["stale_flag_name"]
+groups = ["delete_enum_entry"]


### PR DESCRIPTION
**Changes**
Add an example of using the flag cleanup drone plugin to the java sdk repo.
A user can follow the instructions to run the docker container from the code_cleanup_examples directory to see the if else block for STALE_FLAG being removed. 

```
docker run -v ${PWD}:/java-sdk -e PLUGIN_DEBUG=true -e PLUGIN_PATH_TO_CODEBASE="/java-sdk" -e PLUGIN_PATH_TO_CONFIGURATIONS="/java-sdk/config" -e PLUGIN_LANGUAGE="java" -e PLUGIN_SUBSTITUTIONS="stale_flag_name=STALE_FLAG,treated=true,treated_complement=false" harness/flag_cleanup:latest
```

Extra docs on how adapt this example and configure this for your own custom repo will be added next week in the main https://github.com/harness/flag_cleanup repo.