### PR TITLE
Reduce Guava usage (in preparation for removal)

### DIFF
--- a/src/main/java/io/harness/cf/client/api/Evaluator.java
+++ b/src/main/java/io/harness/cf/client/api/Evaluator.java
@@ -2,7 +2,7 @@ package io.harness.cf.client.api;
 
 import static io.harness.cf.client.api.Operators.*;
 
-import com.google.common.base.Strings;
+import io.harness.cf.client.common.StringUtils;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.sangupta.murmur.Murmur3;
@@ -27,7 +27,7 @@ class Evaluator implements Evaluation {
   }
 
   protected Optional<Object> getAttrValue(Target target, @NonNull String attribute) {
-    if (Strings.isNullOrEmpty(attribute)) {
+    if (StringUtils.isNullOrEmpty(attribute)) {
       log.debug("Attribute is empty");
       return Optional.empty();
     }

--- a/src/main/java/io/harness/cf/client/api/MetricsProcessor.java
+++ b/src/main/java/io/harness/cf/client/api/MetricsProcessor.java
@@ -1,6 +1,5 @@
 package io.harness.cf.client.api;
 
-import com.google.common.base.Strings;
 import com.google.common.util.concurrent.AbstractScheduledService;
 import com.google.common.util.concurrent.AtomicLongMap;
 import io.harness.cf.client.connector.Connector;
@@ -232,7 +231,7 @@ class MetricsProcessor extends AbstractScheduledService {
       }
 
       targetData.setIdentifier(target.getIdentifier());
-      if (Strings.isNullOrEmpty(target.getName())) {
+      if (StringUtils.isNullOrEmpty(target.getName())) {
         targetData.setName(target.getIdentifier());
       } else {
         targetData.setName(target.getName());

--- a/src/main/java/io/harness/cf/client/api/MetricsProcessor.java
+++ b/src/main/java/io/harness/cf/client/api/MetricsProcessor.java
@@ -2,6 +2,7 @@ package io.harness.cf.client.api;
 
 import com.google.common.util.concurrent.AbstractScheduledService;
 import com.google.common.util.concurrent.AtomicLongMap;
+import io.harness.cf.client.common.StringUtils;
 import io.harness.cf.client.connector.Connector;
 import io.harness.cf.client.connector.ConnectorException;
 import io.harness.cf.client.dto.Target;

--- a/src/main/java/io/harness/cf/client/common/StringUtils.java
+++ b/src/main/java/io/harness/cf/client/common/StringUtils.java
@@ -1,0 +1,13 @@
+package io.harness.cf.client.common;
+
+import javax.annotation.CheckForNull;
+
+public class StringUtils {
+
+  /** Private constructor to disallow instantiating util class */
+  private StringUtils() {}
+
+  public static boolean isNullOrEmpty(@CheckForNull String string) {
+    return string == null || string.isEmpty();
+  }
+}

--- a/src/main/java/io/harness/cf/client/connector/FileWatcher.java
+++ b/src/main/java/io/harness/cf/client/connector/FileWatcher.java
@@ -1,6 +1,5 @@
 package io.harness.cf.client.connector;
 
-import com.google.common.base.Strings;
 import com.sun.nio.file.SensitivityWatchEventModifier;
 import io.harness.cf.client.dto.Message;
 import java.io.IOException;
@@ -91,7 +90,7 @@ class FileWatcher implements Runnable, AutoCloseable, Service {
 
   public static String removeFileExtension(
       @NonNull final String filename, final boolean removeAllExtensions) {
-    if (Strings.isNullOrEmpty(filename)) {
+    if (StringUtils.isNullOrEmpty(filename)) {
       return filename;
     }
 

--- a/src/main/java/io/harness/cf/client/connector/FileWatcher.java
+++ b/src/main/java/io/harness/cf/client/connector/FileWatcher.java
@@ -1,6 +1,7 @@
 package io.harness.cf.client.connector;
 
 import com.sun.nio.file.SensitivityWatchEventModifier;
+import io.harness.cf.client.common.StringUtils;
 import io.harness.cf.client.dto.Message;
 import java.io.IOException;
 import java.nio.file.*;

--- a/src/main/java/io/harness/cf/client/dto/Target.java
+++ b/src/main/java/io/harness/cf/client/dto/Target.java
@@ -1,8 +1,9 @@
 package io.harness.cf.client.dto;
 
-import com.google.common.base.Strings;
 import java.util.Map;
 import java.util.Set;
+
+import io.harness.cf.client.common.StringUtils;
 import lombok.*;
 
 @Builder
@@ -30,7 +31,7 @@ public class Target {
 
   public boolean isValid() {
 
-    return !Strings.isNullOrEmpty(identifier);
+    return !StringUtils.isNullOrEmpty(identifier);
   }
 
   public io.harness.cf.model.Target ApiTarget() {

--- a/src/test/java/io/harness/cf/client/api/CfClientTest.java
+++ b/src/test/java/io/harness/cf/client/api/CfClientTest.java
@@ -8,7 +8,6 @@ import static io.harness.cf.client.api.dispatchers.Endpoints.AUTH_ENDPOINT;
 import static io.harness.cf.client.connector.HarnessConnectorUtils.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.gson.JsonObject;
 import io.harness.cf.client.api.dispatchers.*;
 import io.harness.cf.client.api.testutils.DummyConnector;
@@ -17,6 +16,7 @@ import io.harness.cf.client.dto.Target;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.time.Duration;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -69,6 +69,9 @@ class CfClientTest {
 
   @Test
   void testConstructors() throws IOException {
+    HashSet<String> privateAttributes = new HashSet<>();
+    privateAttributes.add("privateFeature1");
+    privateAttributes.add("privateFeature2");
 
     final Config config =
         Config.builder()
@@ -79,7 +82,7 @@ class CfClientTest {
             .frequency(321)
             .bufferSize(999)
             .allAttributesPrivate(true)
-            .privateAttributes(ImmutableSet.of("privateFeature1", "privateFeature2"))
+            .privateAttributes(privateAttributes)
             .metricsServiceAcceptableDuration(9999)
             .debug(true)
             .cache(new DummyCache())

--- a/src/test/java/io/harness/cf/client/common/StringUtilsTest.java
+++ b/src/test/java/io/harness/cf/client/common/StringUtilsTest.java
@@ -1,0 +1,19 @@
+package io.harness.cf.client.common;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class StringUtilsTest {
+
+    @Test
+    public void isNullOrEmpty() {
+        assertTrue(StringUtils.isNullOrEmpty(""));
+        assertTrue(StringUtils.isNullOrEmpty(null));
+        
+        assertFalse(StringUtils.isNullOrEmpty(" "));
+        assertFalse(StringUtils.isNullOrEmpty("Some Value"));
+        assertFalse(StringUtils.isNullOrEmpty("Some Value With Spaces "));
+    }
+
+}


### PR DESCRIPTION
## What
In support of  #143 to remove Guava as a dependency this remove the usage of `Strings.isNullOrEmpty` and `ImmutableSet.of`

## Why
These methods are just a few lines of simple code that can be self contained in the Java SDK

## Testing
Unit test added for StringUtils.isNullOrEmpty

