### PR TITLE
Open the Evaluator and Query class/interfaces to allow usage

### DIFF
--- a/src/main/java/io/harness/cf/client/api/Evaluator.java
+++ b/src/main/java/io/harness/cf/client/api/Evaluator.java
@@ -16,7 +16,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.slf4j.MDC;
 
 @Slf4j
-class Evaluator implements Evaluation {
+public class Evaluator implements Evaluation {
 
   public static final int ONE_HUNDRED = 100;
 

--- a/src/main/java/io/harness/cf/client/api/Query.java
+++ b/src/main/java/io/harness/cf/client/api/Query.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.Optional;
 import lombok.NonNull;
 
-interface Query {
+public interface Query {
 
   Optional<FeatureConfig> getFlag(@NonNull String identifier);
 


### PR DESCRIPTION
Addresses #142 

## What
This makes the `Evaluator` class and `Query` interface public, allowing users to instantiate their own instances.

## Why
Since the `cache` is already injectable, it can be reused with a users own instance of the `Evaluator` class. So if a user can instantiate their own instance of the `Evaluator` class, they can do evaluations on all flags, without triggering metric reporting.

This is needed in my case since we send pre-evaluated flags to the browser to do some simple JS based feature flagging.

## Testing
No testing is needed, this merely open up classes for instantiation.