### PR TITLE
FFM-5915 - Remove oksse dependency

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.harness.featureflags</groupId>
     <artifactId>examples</artifactId>
-    <version>1.2.2</version>
+    <version>1.2.3</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.harness</groupId>
     <artifactId>ff-java-server-sdk</artifactId>
-    <version>1.2.2</version>
+    <version>1.2.3</version>
     <packaging>jar</packaging>
     <name>Harness Feature Flag Java Server SDK</name>
     <description>Harness Feature Flag Java Server SDK</description>
@@ -70,17 +70,15 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>jitpack.io</id>
-            <url>https://jitpack.io</url>
-        </repository>
-    </repositories>
-
     <dependencies>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
+            <version>4.9.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp-sse</artifactId>
             <version>4.9.3</version>
         </dependency>
         <dependency>
@@ -130,11 +128,6 @@
             <version>2.8.5</version>
         </dependency>
 
-        <dependency>
-            <groupId>com.github.heremaps</groupId>
-            <artifactId>oksse</artifactId>
-            <version>0.9.0</version>
-        </dependency>
         <dependency>
             <groupId>com.sangupta</groupId>
             <artifactId>murmur</artifactId>

--- a/src/main/java/io/harness/cf/client/api/InnerClient.java
+++ b/src/main/java/io/harness/cf/client/api/InnerClient.java
@@ -219,7 +219,6 @@ class InnerClient
 
   @Override
   public void onDisconnected() {
-    log.info("onDisconnected triggered, starting poller to get latest flags");
     // onDisconnected can be called multiple times from updater because of retries
     // and we cannot create many poller instances so we need to check if
     // on closing the client, state of the poller and when poller is last time started
@@ -231,6 +230,8 @@ class InnerClient
     if (!closing
         && pollProcessor.state() == Service.State.TERMINATED
         && now.after(Date.from(instant))) {
+      log.info("onDisconnected triggered, starting poller to get latest flags");
+
       pollProcessor =
           new PollingProcessor(connector, repository, options.getPollIntervalInSeconds(), this);
       pollProcessor.start();
@@ -243,6 +244,8 @@ class InnerClient
           pollerStartedAt.toInstant(),
           options.getPollIntervalInSeconds(),
           now.toInstant());
+      log.info("SSE disconnect detected - asking poller to refresh flags");
+      pollProcessor.retrieveAll();
     }
   }
 

--- a/src/main/java/io/harness/cf/client/api/PollingProcessor.java
+++ b/src/main/java/io/harness/cf/client/api/PollingProcessor.java
@@ -78,11 +78,15 @@ class PollingProcessor extends AbstractScheduledService {
     return completableFuture;
   }
 
+  public void retrieveAll() {
+    CompletableFuture.allOf(retrieveFlags(), retrieveSegments()).join();
+  }
+
   @Override
   protected void runOneIteration() {
     log.debug("running poll iteration");
     try {
-      CompletableFuture.allOf(retrieveFlags(), retrieveSegments()).join();
+      retrieveAll();
       if (!initialized) {
         initialized = true;
         log.info("PollingProcessor initialized");

--- a/src/test/java/io/harness/cf/client/connector/EventSourceTest.java
+++ b/src/test/java/io/harness/cf/client/connector/EventSourceTest.java
@@ -93,7 +93,7 @@ class EventSourceTest {
 
     assertTrue(updater.getConnectCount().get() >= 1);
     assertEquals(0, updater.getFailureCount().get());
-    assertEquals(5, updater.getErrorCount().get());
+    assertEquals(3, updater.getErrorCount().get());
   }
 
   @Test


### PR DESCRIPTION
FFM-5915 - Remove oksse dependency

What
Remove oksse dependency and use okhttp-sse instead. Added a retry inteceptor since okhttp-see does not provide any backoff/retry support

Why
We're getting reports of customers having difficulty running the SDK because of missing dependency oksse. oksee was only ever published once to 1 repository and has not been mirrored globally, this means that unless the user has the exact repo in their POM/Gradle file (JitPack) they will more often than not hit this problem at compile time.

Testing
Unit tests + manual proxy