### PR TITLE
FFM-8133 - Java SDK - Update maven-model dependency to 3.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-model</artifactId>
-            <version>3.3.9</version>
+            <version>3.5.0</version>
         </dependency>
         <dependency>
             <groupId>org.threeten</groupId>


### PR DESCRIPTION
What
Update maven-model dependency to 3.5.0 to remove CVE-2022-4245