### PR TITLE
FFM-6412 - Flags with multiple prerequisites evaluating incorrectly

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.harness.featureflags</groupId>
     <artifactId>examples</artifactId>
-    <version>1.2.3</version>
+    <version>1.2.4</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>io.harness</groupId>
             <artifactId>ff-java-server-sdk</artifactId>
-            <version>1.2.3</version>
+            <version>1.2.4</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.harness</groupId>
     <artifactId>ff-java-server-sdk</artifactId>
-    <version>1.2.3</version>
+    <version>1.2.4</version>
     <packaging>jar</packaging>
     <name>Harness Feature Flag Java Server SDK</name>
     <description>Harness Feature Flag Java Server SDK</description>

--- a/src/main/java/io/harness/cf/client/api/Evaluator.java
+++ b/src/main/java/io/harness/cf/client/api/Evaluator.java
@@ -2,11 +2,11 @@ package io.harness.cf.client.api;
 
 import static io.harness.cf.client.api.Operators.*;
 
-import io.harness.cf.client.common.StringUtils;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.sangupta.murmur.Murmur3;
 import com.sangupta.murmur.MurmurConstants;
+import io.harness.cf.client.common.StringUtils;
 import io.harness.cf.client.dto.Target;
 import io.harness.cf.model.*;
 import java.util.*;
@@ -341,7 +341,9 @@ public class Evaluator implements Evaluation {
                 element -> element.contains(preReqEvaluatedVariation.get().getIdentifier()))) {
           return false;
         } else {
-          return checkPreRequisite(preReqFeatureConfig.get(), target);
+          if (!checkPreRequisite(preReqFeatureConfig.get(), target)) {
+            return false;
+          }
         }
       }
     }


### PR DESCRIPTION
FFM-6412 - Flags with multiple prerequisites evaluating incorrectly

What
Fix prerequisites loop in the evaluator code

Why
Only the first parent feature is being processed by the evalator due to the loop exiting too early.

Testing
TestEvaluations_ServerSDK + unit tests passing

The following server evaluation tests now pass with this fix:

Custom_SDK_:_Type=BoolWith2JSON;State=Enabled;On=True;Off=False;Prereq=AlwaysOn;AlwaysOff;Return_False
Custom_SDK_:_Type=BoolWith2JSON;State=Enabled;On=True;Off=False;Prereq=AlwaysOn;AlwaysOnToo;Return_False
Custom_SDK_:_Type=BoolWith2Str;State=Enabled;On=True;Off=False;Prereq=AlwaysOn;AlwaysOnToo;Return_False
Custom_SDK_:_Type=BoolWith2Bool;State=Enabled;On=True;Off=False;Prereq=AlwaysOn;AlwaysOnToo;Return_False
Custom_SDK_:_Type=JSONWith2Bool;State=Enabled;On=Com;Off=Val;Prereq=AlwaysOn;AlwaysOnToo;Return_Val
Custom_SDK_:_Type=JSONWith2JSON;State=Enabled;On=Com;Off=Val;Prereq=AlwaysOn;AlwaysOff;Return_Val
Custom_SDK_:_Type=JSONWith2JSON;State=Enabled;On=Com;Off=Val;Prereq=AlwaysOn;AlwaysOnToo;Return_Val
Custom_SDK_:_Type=JSONWith2Str;State=Enabled;On=Com;Off=Val;Prereq=AlwaysOn;AlwaysOff;Return_Val
Custom_SDK_:_Type=JSONWith2Str;State=Enabled;On=Com;Off=Val;Prereq=AlwaysOn;AlwaysOnToo;Return_Val
Custom_SDK_:_Type=JSONWithJSONBool;State=Enabled;On=Com;Off=Val;Prereq=AlwaysOn;AlwaysOff;Return_Val
Custom_SDK_:_Type=JSONWithJSONBool;State=Enabled;On=Com;Off=Val;Prereq=AlwaysOn;AlwaysOnToo;Return_Val
Custom_SDK_:_Type=JSONWithJSONNum;State=Enabled;On=Com;Off=Val;Prereq=AlwaysOn;AlwaysOnToo;Return_Val
Custom_SDK_:_Type=JSONWithJSONStr;State=Enabled;On=Com;Off=Val;Prereq=AlwaysOn;AlwaysOff;Return_Val
Custom_SDK_:_Type=JSONWithJSONStr;State=Enabled;On=Com;Off=Val;Prereq=AlwaysOn;AlwaysOnToo;Return_Val
Custom_SDK_:_Type=NumWith2Bool;State=Enabled;On=2;Off=0.11;Prereq=AlwaysOn;AlwaysOnToo;Return_0.11
Custom_SDK_:_Type=NumWith2JSON;State=Enabled;On=2;Off=0.11;Prereq=AlwaysOn;AlwaysOff;Return_0.11
Custom_SDK_:_Type=NumWith2JSON;State=Enabled;On=2;Off=0.11;Prereq=AlwaysOn;AlwaysOnToo;Return_0.11
Custom_SDK_:_Type=NumWith2Str;State=Enabled;On=2;Off=0.11;Prereq=AlwaysOn;AlwaysOff;Return_0.11
Custom_SDK_:_Type=NumWithNumBool;State=Enabled;On=2;Off=0.11;Prereq=AlwaysOn;AlwaysOnToo;Return_0.11
Custom_SDK_:_Type=NumWithNumStr;State=Enabled;On=2;Off=0.11;Prereq=AlwaysOn;AlwaysOff;Return_0.11
Custom_SDK_:_Type=NumWithNumStr;State=Enabled;On=2;Off=0.11;Prereq=AlwaysOn;AlwaysOnToo;Return_0.11