### PR TITLE
[FFM-8688] - Handle accountID as an optional field in the JWT token

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.harness.featureflags</groupId>
     <artifactId>examples</artifactId>
-    <version>1.2.4</version>
+    <version>1.2.5</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>io.harness</groupId>
             <artifactId>ff-java-server-sdk</artifactId>
-            <version>1.2.4</version>
+            <version>1.2.5</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.harness</groupId>
     <artifactId>ff-java-server-sdk</artifactId>
-    <version>1.2.4</version>
+    <version>1.2.5</version>
     <packaging>jar</packaging>
     <name>Harness Feature Flag Java Server SDK</name>
     <description>Harness Feature Flag Java Server SDK</description>

--- a/src/test/java/io/harness/cf/client/api/dispatchers/CannedResponses.java
+++ b/src/test/java/io/harness/cf/client/api/dispatchers/CannedResponses.java
@@ -72,17 +72,35 @@ public class CannedResponses {
   }
 
   public static String makeDummyJwtToken() {
+    return makeDummyJwtToken(
+        "00000000-0000-0000-0000-000000000000", "Production", "aaaaa_BBBBB-cccccccccc");
+  }
+
+  public static String makeDummyJwtToken(String envUuid, String env, String accountID) {
     final String header = "{\"alg\":\"HS256\",\"typ\":\"JWT\"}";
-    final String payload =
-        "{\"environment\":\"00000000-0000-0000-0000-000000000000\","
-            + "\"environmentIdentifier\":\"Production\","
-            + "\"project\":\"00000000-0000-0000-0000-000000000000\","
+    String payload = "{";
+
+    if (envUuid != null) {
+      payload += "\"environment\":\"" + envUuid + "\",";
+    }
+
+    if (env != null) {
+      payload += "\"environmentIdentifier\":\"" + env + "\",";
+    }
+
+    if (accountID != null) {
+      payload += "\"accountID\":\"" + accountID + "\",";
+    }
+
+    payload +=
+        "\"project\":\"00000000-0000-0000-0000-000000000000\","
             + "\"projectIdentifier\":\"dev\","
-            + "\"accountID\":\"aaaaa_BBBBB-cccccccccc\","
             + "\"organization\":\"00000000-0000-0000-0000-000000000000\","
             + "\"organizationIdentifier\":\"default\","
             + "\"clusterIdentifier\":\"1\","
-            + "\"key_type\":\"Server\"}";
+            + "\"key_type\":\"Server\""
+            + "}";
+
     final byte[] hmac256 = new byte[32];
     return Base64.getEncoder().encodeToString(header.getBytes(StandardCharsets.UTF_8))
         + "."

--- a/src/test/java/io/harness/cf/client/api/dispatchers/CannedResponses.java
+++ b/src/test/java/io/harness/cf/client/api/dispatchers/CannedResponses.java
@@ -39,6 +39,12 @@ public class CannedResponses {
     return makeMockJsonResponse(httpCode, "{\"authToken\": \"" + makeDummyJwtToken() + "\"}");
   }
 
+  public static MockResponse makeAuthResponse(
+      int httpCode, String envUuid, String env, String accountId) {
+    return makeMockJsonResponse(
+        httpCode, "{\"authToken\": \"" + makeDummyJwtToken(envUuid, env, accountId) + "\"}");
+  }
+
   public static MockResponse makeMockStreamResponse(int httpCode, Event... events) {
 
     final StringBuilder builder = new StringBuilder();

--- a/src/test/java/io/harness/cf/client/api/dispatchers/JwtMissingFieldsAuthDispatcher.java
+++ b/src/test/java/io/harness/cf/client/api/dispatchers/JwtMissingFieldsAuthDispatcher.java
@@ -1,0 +1,128 @@
+package io.harness.cf.client.api.dispatchers;
+
+import static io.harness.cf.client.api.TestUtils.makeBasicFeatureJson;
+import static io.harness.cf.client.api.TestUtils.makeSegmentsJson;
+import static io.harness.cf.client.api.dispatchers.CannedResponses.*;
+import static io.harness.cf.client.api.dispatchers.Endpoints.*;
+
+import io.harness.cf.client.api.testutils.PollingAtomicLong;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.Getter;
+import lombok.SneakyThrows;
+import okhttp3.Headers;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
+import okhttp3.mockwebserver.SocketPolicy;
+import org.jetbrains.annotations.NotNull;
+
+public class JwtMissingFieldsAuthDispatcher extends TestWebServerDispatcher {
+  private final AtomicInteger version = new AtomicInteger(2);
+  @Getter private final PollingAtomicLong endpointsHit;
+  @Getter private final List<Exception> errors = new ArrayList<>();
+
+  private final String jwtEnvironmentIdentifier;
+  private final String jwtAccountId;
+  /* Set to null whatever fields you're testing in the JWT token */
+  public JwtMissingFieldsAuthDispatcher(String jwtEnvironmentIdentifier, String jwtAccountId) {
+    this.jwtEnvironmentIdentifier = jwtEnvironmentIdentifier;
+    this.jwtAccountId = jwtAccountId;
+    endpointsHit = new PollingAtomicLong(5);
+  }
+
+  @Override
+  @SneakyThrows
+  @NotNull
+  public MockResponse dispatch(@NotNull RecordedRequest recordedRequest) {
+    System.out.printf(
+        "DISPATCH GOT ------> %s  jwtEnvironmentIdentifier='%s' jwtAccountId='%s'\n",
+        recordedRequest.getPath(), jwtEnvironmentIdentifier, jwtAccountId);
+
+    endpointsHit.incrementAndGet();
+
+    switch (Objects.requireNonNull(recordedRequest.getPath())) {
+      case AUTH_ENDPOINT:
+        return makeAuthResponse(
+            200, "00000000-0000-0000-0000-000000000000", jwtEnvironmentIdentifier, jwtAccountId);
+      case FEATURES_ENDPOINT:
+        assertHeaders(recordedRequest);
+        return makeMockJsonResponse(200, makeBasicFeatureJson());
+      case SEGMENTS_ENDPOINT:
+        assertHeaders(recordedRequest);
+        return makeMockJsonResponse(200, makeSegmentsJson());
+      case STREAM_ENDPOINT:
+        assertHeaders(recordedRequest);
+        return makeMockStreamResponse(
+            200, makeFlagPatchEvent("simplebool", version.getAndIncrement()));
+      case SIMPLE_BOOL_FLAG_ENDPOINT:
+        assertHeaders(recordedRequest);
+        return makeMockSingleBoolFlagResponse(200, "simplebool", "off", version.get());
+        // TODO add metrics here
+      default:
+        throw new UnsupportedOperationException(
+            "ERROR: url not mapped " + recordedRequest.getPath());
+    }
+  }
+
+  private MockResponse makeAssertFailResp(String msg) {
+    return new MockResponse()
+        .setSocketPolicy(SocketPolicy.SHUTDOWN_SERVER_AFTER_RESPONSE)
+        .setResponseCode(-1)
+        .setStatus(msg);
+  }
+
+  private void assertHeaders(RecordedRequest recordedRequest) {
+    final Headers headers = recordedRequest.getHeaders();
+    final String url = recordedRequest.getPath();
+
+    System.out.print(headers);
+
+    final String accountVal = headers.get("Harness-AccountID");
+    if (jwtAccountId == null || jwtAccountId.trim().isEmpty()) {
+      if (accountVal != null) {
+        errors.add(
+            new RuntimeException(
+                String.format(
+                    "Harness-AccountID=%s header should not be present on req '%s'",
+                    accountVal, url)));
+      }
+    } else {
+      if (!jwtAccountId.equals(accountVal)) {
+        errors.add(
+            new RuntimeException(
+                String.format(
+                    "Harness-AccountID=%s header does not match JWT accountID '%s' on req '%s'",
+                    accountVal, jwtAccountId, url)));
+      }
+    }
+
+    final String envIdVal = headers.get("Harness-EnvironmentID");
+    if (jwtEnvironmentIdentifier == null || jwtEnvironmentIdentifier.trim().isEmpty()) {
+      if (!"00000000-0000-0000-0000-000000000000".equals(envIdVal)) {
+        errors.add(
+            new RuntimeException(
+                String.format(
+                    "Harness-EnvironmentID=%s header should fallback to UUID when environmentIdentifier is null on req '%s'",
+                    envIdVal, url)));
+      }
+    } else {
+      if (!jwtEnvironmentIdentifier.equals(envIdVal)) {
+        errors.add(
+            new RuntimeException(
+                String.format(
+                    "Harness-EnvironmentID=%s does not match JWT environmentIdentifier '%s' on req '%s'",
+                    envIdVal, jwtEnvironmentIdentifier, url)));
+      }
+    }
+  }
+
+  public void waitForAllEndpointsToBeCalled(int waitTimeSeconds) throws InterruptedException {
+    endpointsHit.waitForMinimumValueToBeReached(
+        waitTimeSeconds,
+        "auth/feat/seg/stream/flag",
+        "Did not get minimum number of endpoint calls");
+    Thread.sleep(500); // give time for resp to get back
+  }
+}

--- a/src/test/java/io/harness/cf/client/connector/HarnessConnectorTest.java
+++ b/src/test/java/io/harness/cf/client/connector/HarnessConnectorTest.java
@@ -1,11 +1,23 @@
 package io.harness.cf.client.connector;
 
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import io.harness.cf.ApiClient;
+import io.harness.cf.api.ClientApi;
+import io.harness.cf.api.MetricsApi;
 import io.harness.cf.client.api.MissingSdkKeyException;
+import io.harness.cf.client.api.dispatchers.CannedResponses;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.stubbing.Answer;
 
 class HarnessConnectorTest {
 
@@ -29,5 +41,137 @@ class HarnessConnectorTest {
             () -> new HarnessConnector(null, mock(HarnessConfig.class)),
             "Exception was not thrown");
     assertInstanceOf(NullPointerException.class, thrown);
+  }
+
+  <T> Answer<T> makeCaptureHeadersAnswer(Map<String, String> capturedHeaders) {
+    return params -> {
+      String h = String.valueOf((String) params.getArgument(0));
+      String v = String.valueOf((String) params.getArgument(1));
+      System.out.printf("adding %s=%s\n", h, v);
+      capturedHeaders.put(h, v);
+      return null;
+    };
+  }
+
+  void setupHeaderCaptures(
+      ClientApi mockClientApi,
+      Map<String, String> capturedApiHeaders,
+      MetricsApi mockMetricsApi,
+      Map<String, String> capturedMetricApiHeaders) {
+    final ApiClient mockInternalApiClient = mock(ApiClient.class);
+    when(mockClientApi.getApiClient()).thenReturn(mockInternalApiClient);
+    when(mockInternalApiClient.addDefaultHeader(anyString(), anyString()))
+        .thenAnswer(makeCaptureHeadersAnswer(capturedApiHeaders));
+
+    final ApiClient mockInternalMetricsApiClient = mock(ApiClient.class);
+    when(mockMetricsApi.getApiClient()).thenReturn(mockInternalMetricsApiClient);
+    when(mockInternalMetricsApiClient.addDefaultHeader(anyString(), anyString()))
+        .thenAnswer(makeCaptureHeadersAnswer(capturedMetricApiHeaders));
+  }
+
+  @ParameterizedTest
+  @NullSource()
+  @ValueSource(strings = {"", " ", "\t", "\n", "\r"})
+  void shouldParseJwtTokenWithMissingAccountId(String accountId) {
+    final Map<String, String> apiHeaders = new HashMap<>();
+    final Map<String, String> metricApiHeaders = new HashMap<>();
+
+    final ClientApi mockClientApi = mock(ClientApi.class);
+    final MetricsApi mockMetricsApi = mock(MetricsApi.class);
+    setupHeaderCaptures(mockClientApi, apiHeaders, mockMetricsApi, metricApiHeaders);
+
+    final HarnessConnector connector =
+        new HarnessConnector(
+            "dummy_sdk_key", mock(HarnessConfig.class), mockClientApi, mockMetricsApi);
+
+    final String token = CannedResponses.makeDummyJwtToken("dummyUUID", "dev", accountId);
+    connector.processToken(token);
+
+    for (Map<String, String> nextMap : Arrays.asList(apiHeaders, metricApiHeaders)) {
+      System.out.print(nextMap);
+      assertEquals(2, nextMap.size());
+      assertEquals("Bearer " + token, nextMap.get("Authorization"));
+      assertEquals("dev", nextMap.get("Harness-EnvironmentID"));
+      assertFalse(nextMap.containsKey("Harness-AccountID"));
+    }
+  }
+
+  @Test
+  void shouldAddHarnessEnvironmentIdHeader() {
+    final Map<String, String> apiHeaders = new HashMap<>();
+    final Map<String, String> metricApiHeaders = new HashMap<>();
+
+    final ClientApi mockClientApi = mock(ClientApi.class);
+    final MetricsApi mockMetricsApi = mock(MetricsApi.class);
+    setupHeaderCaptures(mockClientApi, apiHeaders, mockMetricsApi, metricApiHeaders);
+
+    final HarnessConnector connector =
+        new HarnessConnector(
+            "dummy_sdk_key", mock(HarnessConfig.class), mockClientApi, mockMetricsApi);
+
+    final String token = CannedResponses.makeDummyJwtToken("dummyUUID", "non_uuid_env_name", "acc");
+    connector.processToken(token);
+
+    for (Map<String, String> nextMap : Arrays.asList(apiHeaders, metricApiHeaders)) {
+      System.out.print(nextMap);
+      assertEquals(3, nextMap.size());
+      assertEquals("Bearer " + token, nextMap.get("Authorization"));
+      assertEquals("non_uuid_env_name", nextMap.get("Harness-EnvironmentID"));
+      assertEquals("acc", nextMap.get("Harness-AccountID"));
+    }
+  }
+
+  @ParameterizedTest
+  @NullSource()
+  @ValueSource(strings = {"", " ", "\t", "\n", "\r"})
+  void shouldAddHarnessEnvironmentIdHeaderButFallbackToUuidEnvIfEnvNotPresent(String env) {
+    final Map<String, String> apiHeaders = new HashMap<>();
+    final Map<String, String> metricApiHeaders = new HashMap<>();
+
+    final ClientApi mockClientApi = mock(ClientApi.class);
+    final MetricsApi mockMetricsApi = mock(MetricsApi.class);
+    setupHeaderCaptures(mockClientApi, apiHeaders, mockMetricsApi, metricApiHeaders);
+
+    final HarnessConnector connector =
+        new HarnessConnector(
+            "dummy_sdk_key", mock(HarnessConfig.class), mockClientApi, mockMetricsApi);
+
+    final String token = CannedResponses.makeDummyJwtToken("dummyUUID", env, "acc");
+    connector.processToken(token);
+
+    for (Map<String, String> nextMap : Arrays.asList(apiHeaders, metricApiHeaders)) {
+      System.out.print(nextMap);
+      assertEquals(3, nextMap.size());
+      assertEquals("Bearer " + token, nextMap.get("Authorization"));
+      assertEquals("dummyUUID", nextMap.get("Harness-EnvironmentID"));
+      assertEquals("acc", nextMap.get("Harness-AccountID"));
+    }
+  }
+
+  @ParameterizedTest
+  @NullSource()
+  @ValueSource(strings = {"", " ", "\t", "\n", "\r"})
+  void shouldNotAddHarnessEnvironmentIdHeaderIfNeitherEnvOrEnvUuidPresent(String env) {
+    final Map<String, String> apiHeaders = new HashMap<>();
+    final Map<String, String> metricApiHeaders = new HashMap<>();
+
+    final ClientApi mockClientApi = mock(ClientApi.class);
+    final MetricsApi mockMetricsApi = mock(MetricsApi.class);
+    setupHeaderCaptures(mockClientApi, apiHeaders, mockMetricsApi, metricApiHeaders);
+
+    final HarnessConnector connector =
+        new HarnessConnector(
+            "dummy_sdk_key", mock(HarnessConfig.class), mockClientApi, mockMetricsApi);
+
+    final String token = CannedResponses.makeDummyJwtToken(null, env, "acc");
+    connector.processToken(token);
+
+    for (Map<String, String> nextMap : Arrays.asList(apiHeaders, metricApiHeaders)) {
+      System.out.print(nextMap);
+      assertEquals(2, nextMap.size());
+      assertEquals("Bearer " + token, nextMap.get("Authorization"));
+      assertEquals("acc", nextMap.get("Harness-AccountID"));
+      assertFalse(nextMap.containsKey("Harness-EnvironmentID"));
+    }
   }
 }


### PR DESCRIPTION
[FFM-8688] - Handle accountID as an optional field in the JWT token

What
Adding new unit tests + harden the existing JWT parsing code to handle information which may be optional when an ff-proxy is in use. If the info is not available the header will not be added. Also fixed env header to fall back to UUID when not present.

Why
The proxy doesn’t send accountID in the JWT token on auth, so we should make sure the code handles this correctly without bailing out when a proxy is in use.

Testing
New unit tests written + manual

[FFM-8688]: https://harness.atlassian.net/browse/FFM-8688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ