### PR TITLE
[FFM-8148] - Standardise SDK error codes

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.harness.featureflags</groupId>
     <artifactId>examples</artifactId>
-    <version>1.2.5</version>
+    <version>1.3.0-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>io.harness</groupId>
             <artifactId>ff-java-server-sdk</artifactId>
-            <version>1.2.5</version>
+            <version>1.3.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.harness</groupId>
     <artifactId>ff-java-server-sdk</artifactId>
-    <version>1.2.5</version>
+    <version>1.3.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Harness Feature Flag Java Server SDK</name>
     <description>Harness Feature Flag Java Server SDK</description>

--- a/src/main/java/io/harness/cf/client/api/AuthService.java
+++ b/src/main/java/io/harness/cf/client/api/AuthService.java
@@ -1,6 +1,7 @@
 package io.harness.cf.client.api;
 
 import com.google.common.util.concurrent.AbstractScheduledService;
+import io.harness.cf.client.common.SdkCodes;
 import io.harness.cf.client.connector.Connector;
 import io.harness.cf.client.connector.ConnectorException;
 import java.util.concurrent.TimeUnit;
@@ -29,6 +30,7 @@ class AuthService extends AbstractScheduledService {
   protected void runOneIteration() {
     try {
       connector.authenticate();
+      SdkCodes.infoSdkAuthOk();
       callback.onAuthSuccess();
       stopAsync();
       log.info("Stopping Auth service");

--- a/src/main/java/io/harness/cf/client/api/MetricsProcessor.java
+++ b/src/main/java/io/harness/cf/client/api/MetricsProcessor.java
@@ -2,6 +2,7 @@ package io.harness.cf.client.api;
 
 import com.google.common.util.concurrent.AbstractScheduledService;
 import com.google.common.util.concurrent.AtomicLongMap;
+import io.harness.cf.client.common.SdkCodes;
 import io.harness.cf.client.common.StringUtils;
 import io.harness.cf.client.connector.Connector;
 import io.harness.cf.client.connector.ConnectorException;
@@ -152,7 +153,7 @@ class MetricsProcessor extends AbstractScheduledService {
           }
           log.info("Successfully sent analytics data to the server");
         } catch (ConnectorException e) {
-          log.error("Exception while posting metrics to the event server");
+          SdkCodes.warnPostMetricsFailed(e.getMessage());
         }
       }
       globalTargetSet.addAll(stagingTargetSet);
@@ -268,13 +269,14 @@ class MetricsProcessor extends AbstractScheduledService {
   }
 
   public void start() {
-    log.info("Starting MetricsProcessor with request interval: {}", config.getFrequency());
+    SdkCodes.infoMetricsThreadStarted(config.getFrequency());
     startAsync();
   }
 
   public void stop() {
-    log.info("Stopping MetricsProcessor");
+    log.debug("Stopping MetricsProcessor");
     stopAsync();
+    SdkCodes.infoMetricsThreadExited();
   }
 
   public void close() {

--- a/src/main/java/io/harness/cf/client/api/PollingProcessor.java
+++ b/src/main/java/io/harness/cf/client/api/PollingProcessor.java
@@ -3,6 +3,7 @@ package io.harness.cf.client.api;
 import com.google.common.util.concurrent.AbstractScheduledService;
 import com.google.common.util.concurrent.MoreExecutors;
 import io.harness.cf.client.common.ScheduledServiceStateLogger;
+import io.harness.cf.client.common.SdkCodes;
 import io.harness.cf.client.connector.Connector;
 import io.harness.cf.model.FeatureConfig;
 import io.harness.cf.model.Segment;
@@ -111,7 +112,7 @@ class PollingProcessor extends AbstractScheduledService {
     if (isRunning()) {
       return;
     }
-    log.info("Starting PollingProcessor with request interval: {}", pollIntervalSeconds);
+    SdkCodes.infoPollStarted(pollIntervalSeconds);
     startAsync();
   }
 
@@ -119,7 +120,7 @@ class PollingProcessor extends AbstractScheduledService {
     log.info("Stopping PollingProcessor");
     if (isRunning()) {
       stopAsync();
-      log.info("PollingProcessor stopped");
+      SdkCodes.infoPollingStopped();
     }
   }
 

--- a/src/main/java/io/harness/cf/client/common/SdkCodes.java
+++ b/src/main/java/io/harness/cf/client/common/SdkCodes.java
@@ -38,7 +38,7 @@ public class SdkCodes {
   }
 
   public static void infoStreamEventReceived(String eventJson) {
-    log.info(sdkErrMsg(5002, of(eventJson)));
+    log.info(sdkErrMsg(5002, ofNullable(eventJson)));
   }
 
   public static void infoMetricsThreadStarted(int intervalSec) {
@@ -46,11 +46,11 @@ public class SdkCodes {
   }
 
   public static void infoMetricsThreadExited() {
-    log.info(sdkErrMsg(7000));
+    log.info(sdkErrMsg(7001));
   }
 
   public static void warnAuthFailedSrvDefaults(String reason) {
-    log.warn(sdkErrMsg(2001, Optional.of(reason)));
+    log.warn(sdkErrMsg(2001, Optional.ofNullable(reason)));
   }
 
   public static void warnAuthRetying(int attempt) {
@@ -58,11 +58,11 @@ public class SdkCodes {
   }
 
   public static void warnStreamDisconnected(String reason) {
-    log.warn(sdkErrMsg(5001, Optional.of(reason)));
+    log.warn(sdkErrMsg(5001, Optional.ofNullable(reason)));
   }
 
   public static void warnPostMetricsFailed(String reason) {
-    log.warn(sdkErrMsg(7002, Optional.of(reason)));
+    log.warn(sdkErrMsg(7002, Optional.ofNullable(reason)));
   }
 
   public static void warnDefaultVariationServed(String identifier, Target target, String def) {
@@ -94,13 +94,13 @@ public class SdkCodes {
                 // SDK_STREAM_5xxx
                 {"5000", "SSE stream connected ok"},
                 {"5001", "SSE stream disconnected, reason:"},
-                {"5002", "SSE event received: "},
+                {"5002", "SSE event received:"},
                 {"5003", "SSE retrying to connect in"},
                 // SDK_EVAL_6xxx
                 {"6000", "Evaluated variation successfully"},
                 {"6001", "Default variation was served"},
                 // SDK_METRICS_7xxx
-                {"7000", "Metrics thread started, intervalMs: "},
+                {"7000", "Metrics thread started, intervalMs:"},
                 {"7001", "Metrics thread exited"},
                 {"7002", "Posting metrics failed, reason:"}
               })

--- a/src/main/java/io/harness/cf/client/common/SdkCodes.java
+++ b/src/main/java/io/harness/cf/client/common/SdkCodes.java
@@ -1,0 +1,128 @@
+package io.harness.cf.client.common;
+
+import static java.lang.String.valueOf;
+import static java.util.Optional.*;
+
+import io.harness.cf.client.dto.Target;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class SdkCodes {
+
+  public static void errorMissingSdkKey() {
+    log.error(sdkErrMsg(1002));
+  }
+
+  public static void infoPollStarted(int durationSec) {
+    log.info(sdkErrMsg(4000, of(valueOf(durationSec * 1000))));
+  }
+
+  public static void infoSdkInitOk() {
+    log.info(sdkErrMsg(1000));
+  }
+
+  public static void infoSdkAuthOk() {
+    log.info(sdkErrMsg(2000));
+  }
+
+  public static void infoPollingStopped() {
+    log.info(sdkErrMsg(4001));
+  }
+
+  public static void infoStreamConnected() {
+    log.info(sdkErrMsg(5000));
+  }
+
+  public static void infoStreamEventReceived(String eventJson) {
+    log.info(sdkErrMsg(5002, of(eventJson)));
+  }
+
+  public static void infoMetricsThreadStarted(int intervalSec) {
+    log.info(sdkErrMsg(7000, of(valueOf(intervalSec * 1000))));
+  }
+
+  public static void infoMetricsThreadExited() {
+    log.info(sdkErrMsg(7000));
+  }
+
+  public static void warnAuthFailedSrvDefaults(String reason) {
+    log.warn(sdkErrMsg(2001, Optional.of(reason)));
+  }
+
+  public static void warnAuthRetying(int attempt) {
+    log.warn(sdkErrMsg(2003, Optional.of(", attempt " + attempt)));
+  }
+
+  public static void warnStreamDisconnected(String reason) {
+    log.warn(sdkErrMsg(5001, Optional.of(reason)));
+  }
+
+  public static void warnPostMetricsFailed(String reason) {
+    log.warn(sdkErrMsg(7002, Optional.of(reason)));
+  }
+
+  public static void warnDefaultVariationServed(String identifier, Target target, String def) {
+    String targetId = (target == null) ? "null" : target.getIdentifier();
+    String msg = String.format("identifier=%s, target=%s, default=%s", identifier, targetId, def);
+    log.warn(sdkErrMsg(6001, of(msg)));
+  }
+
+  private static final Map<Integer, String> MAP =
+      Arrays.stream(
+              new String[][] {
+                // SDK_INIT_1xxx
+                {"1000", "The SDK has successfully initialized"},
+                {
+                  "1001",
+                  "The SDK has failed to initialize due to the following authentication error:"
+                },
+                {"1002", "The SDK has failed to initialize due to a missing or empty API key"},
+                // SDK_AUTH_2xxx
+                {"2000", "Authenticated ok"},
+                {
+                  "2001",
+                  "Authentication failed with a non-recoverable error - defaults will be served"
+                },
+                {"2003", "Retrying to authenticate"},
+                // SDK_POLL_4xxx
+                {"4000", "Polling started, intervalMs:"},
+                {"4001", "Polling stopped"},
+                // SDK_STREAM_5xxx
+                {"5000", "SSE stream connected ok"},
+                {"5001", "SSE stream disconnected, reason:"},
+                {"5002", "SSE event received: "},
+                {"5003", "SSE retrying to connect in"},
+                // SDK_EVAL_6xxx
+                {"6000", "Evaluated variation successfully"},
+                {"6001", "Default variation was served"},
+                // SDK_METRICS_7xxx
+                {"7000", "Metrics thread started, intervalMs: "},
+                {"7001", "Metrics thread exited"},
+                {"7002", "Posting metrics failed, reason:"}
+              })
+          .collect(Collectors.toMap(entry -> Integer.parseInt(entry[0]), entry -> entry[1]));
+
+  private static String sdkErrMsg(int error_code) {
+    return sdkErrMsg(error_code, Optional.empty());
+  }
+
+  private static String sdkErrMsg(int error_code, Optional<String> appendText) {
+    return String.format(
+        "SDKCODE(%s:%s): %s %s",
+        getErrClass(error_code), error_code, MAP.get(error_code), appendText.orElse(""));
+  }
+
+  private static String getErrClass(int error_code) {
+    if (error_code >= 1000 && error_code <= 1999) return "init";
+    else if (error_code >= 2000 && error_code <= 2999) return "auth";
+    else if (error_code >= 4000 && error_code <= 4999) return "poll";
+    else if (error_code >= 5000 && error_code <= 5999) return "stream";
+    else if (error_code >= 6000 && error_code <= 6999) return "eval";
+    else if (error_code >= 7000 && error_code <= 7999) return "metric";
+    return "";
+  }
+}

--- a/src/main/java/io/harness/cf/client/connector/HarnessConnector.java
+++ b/src/main/java/io/harness/cf/client/connector/HarnessConnector.java
@@ -6,6 +6,7 @@ import io.harness.cf.ApiException;
 import io.harness.cf.api.ClientApi;
 import io.harness.cf.api.MetricsApi;
 import io.harness.cf.client.api.MissingSdkKeyException;
+import io.harness.cf.client.common.SdkCodes;
 import io.harness.cf.client.dto.Claim;
 import io.harness.cf.client.logger.LogUtil;
 import io.harness.cf.model.*;
@@ -52,6 +53,7 @@ public class HarnessConnector implements Connector, AutoCloseable {
 
   public HarnessConnector(@NonNull final String apiKey, @NonNull final HarnessConfig options) {
     if (isNullOrEmpty(apiKey)) {
+      SdkCodes.errorMissingSdkKey();
       throw new MissingSdkKeyException();
     }
 

--- a/src/main/java/io/harness/cf/client/connector/LocalConnector.java
+++ b/src/main/java/io/harness/cf/client/connector/LocalConnector.java
@@ -210,7 +210,7 @@ public class LocalConnector implements Connector, AutoCloseable {
       log.info("FileWatcherService stopping");
       flagWatcher.stop();
       segmentWatcher.stop();
-      updater.onDisconnected();
+      updater.onDisconnected("LocalConnector stopped");
       log.info("FileWatcherService stopped");
     }
 

--- a/src/main/java/io/harness/cf/client/connector/Updater.java
+++ b/src/main/java/io/harness/cf/client/connector/Updater.java
@@ -5,13 +5,11 @@ import io.harness.cf.client.dto.Message;
 public interface Updater {
   void onConnected();
 
-  void onDisconnected();
+  void onDisconnected(String reason);
 
   void onReady();
 
   void onFailure(final String message);
-
-  void onError();
 
   void update(final Message message);
 }

--- a/src/test/java/io/harness/cf/client/common/SdkCodesTest.java
+++ b/src/test/java/io/harness/cf/client/common/SdkCodesTest.java
@@ -1,0 +1,40 @@
+package io.harness.cf.client.common;
+
+import static io.harness.cf.client.common.SdkCodes.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import io.harness.cf.client.dto.Target;
+import org.junit.jupiter.api.Test;
+
+class SdkCodesTest {
+
+  @Test
+  void testAllLogs() {
+    assertDoesNotThrow(
+        () -> {
+          errorMissingSdkKey();
+          infoPollStarted(123);
+          infoSdkInitOk();
+          infoSdkAuthOk();
+          infoPollingStopped();
+          infoStreamConnected();
+          infoStreamEventReceived(null);
+          infoStreamEventReceived("dummy data");
+          infoMetricsThreadStarted(321);
+          infoMetricsThreadExited();
+          warnAuthFailedSrvDefaults(null);
+          warnAuthFailedSrvDefaults("error 1");
+          warnAuthRetying(1);
+          warnAuthRetying(-1);
+          warnStreamDisconnected("error 2");
+          warnStreamDisconnected(null);
+          warnPostMetricsFailed(null);
+          warnPostMetricsFailed("error 3");
+          warnDefaultVariationServed("id1", null, null);
+          warnDefaultVariationServed("id1", null, "defaultVal");
+
+          Target target = Target.builder().identifier("test").isPrivate(false).build();
+          warnDefaultVariationServed("id2", target, "defaultVal2");
+        });
+  }
+}

--- a/src/test/java/io/harness/cf/client/connector/CountingUpdater.java
+++ b/src/test/java/io/harness/cf/client/connector/CountingUpdater.java
@@ -13,7 +13,6 @@ class CountingUpdater implements Updater {
   @Getter @Setter private PollingAtomicLong readyCount = new PollingAtomicLong(0);
   @Getter @Setter private PollingAtomicLong failureCount = new PollingAtomicLong(0);
   @Getter @Setter private PollingAtomicLong updateCount = new PollingAtomicLong(0);
-  @Getter @Setter private PollingAtomicLong errorCount = new PollingAtomicLong(0);
 
   @Override
   public void onConnected() {
@@ -22,8 +21,8 @@ class CountingUpdater implements Updater {
   }
 
   @Override
-  public void onDisconnected() {
-    log.debug("onDisconnected");
+  public void onDisconnected(String reason) {
+    log.debug("onDisconnected" + reason);
     disconnectCount.incrementAndGet();
   }
 
@@ -37,12 +36,6 @@ class CountingUpdater implements Updater {
   public void onFailure(String message) {
     log.debug("onFailure: " + message);
     failureCount.incrementAndGet();
-  }
-
-  @Override
-  public void onError() {
-    log.info("onError");
-    errorCount.incrementAndGet();
   }
 
   @Override

--- a/src/test/java/io/harness/cf/client/connector/EventSourceTest.java
+++ b/src/test/java/io/harness/cf/client/connector/EventSourceTest.java
@@ -89,7 +89,6 @@ class EventSourceTest {
 
     assertTrue(updater.getConnectCount().get() >= 1);
     assertEquals(0, updater.getFailureCount().get());
-    assertEquals(0, updater.getErrorCount().get());
   }
 
   @Test


### PR DESCRIPTION
[FFM-8148] - Standardise SDK error codes

What
Adding standardised SDK error codes + pushing some logs down to debug to reduce noise

Why
Each SDK uses different log messages for its lifecycle. We want to standardise messages across SDKs with a unique code.

Testing
Manual testing + unit testing

[FFM-8148]: https://harness.atlassian.net/browse/FFM-8148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ