### PR TITLE
[FFM-4023] - JavaSDK local connector doesn't create metrics folder

### DIFF
--- a/src/main/java/io/harness/cf/client/connector/LocalConnector.java
+++ b/src/main/java/io/harness/cf/client/connector/LocalConnector.java
@@ -35,6 +35,8 @@ public class LocalConnector implements Connector, AutoCloseable {
 
   public LocalConnector(@NonNull final String source) {
     this.source = source;
+    Stream.of("flags", "segments", "metrics")
+        .forEach(nextDir -> Paths.get(source, nextDir).toFile().mkdirs());
     log.info("LocalConnector initialized with source {}", source);
   }
 
@@ -55,6 +57,7 @@ public class LocalConnector implements Connector, AutoCloseable {
       throws ConnectorException {
     log.debug("List files in {} with {}", source, domain);
     try {
+      Paths.get(source, domain).toFile().mkdirs();
       Stream<File> fileStream =
           Files.list(Paths.get(source, domain))
               .filter(Files::isRegularFile)

--- a/src/test/java/io/harness/cf/client/connector/LocalConnectorTest.java
+++ b/src/test/java/io/harness/cf/client/connector/LocalConnectorTest.java
@@ -1,0 +1,28 @@
+package io.harness.cf.client.connector;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.harness.cf.model.Metrics;
+import java.util.ArrayList;
+import org.junit.jupiter.api.Test;
+
+class LocalConnectorTest {
+
+  @Test
+  void shouldNotThrowExceptionsIfFoldersDontExist() {
+    String source = "LocalConnectorTestSource";
+
+    Metrics metrics = new Metrics();
+    metrics.metricsData(new ArrayList<>());
+    metrics.targetData(new ArrayList<>());
+
+    assertDoesNotThrow(
+        () -> {
+          LocalConnector connector = new LocalConnector(source);
+          connector.listFiles(source, "domain");
+          connector.getFlags();
+          connector.getSegments();
+          connector.postMetrics(metrics);
+        });
+  }
+}


### PR DESCRIPTION
[FFM-4023] - JavaSDK local connector doesn't create metrics folder

**What**
Fixes exception reported by LocalConnector when sub-folders are missing.

**Why**
LocalConnector needs flags, segments, metrics and a domain folder to exist before writing to them.

**Testing**
New unit test

[FFM-4023]: https://harness.atlassian.net/browse/FFM-4023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ