### PR TITLE
[FFM-9691] - Add support for Java 21

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.24</version>
+            <version>1.18.30</version>
             <scope>provided</scope>
         </dependency>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.harness.featureflags</groupId>
     <artifactId>examples</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>io.harness</groupId>
             <artifactId>ff-java-server-sdk</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.1-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.harness</groupId>
     <artifactId>ff-java-server-sdk</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Harness Feature Flag Java Server SDK</name>
     <description>Harness Feature Flag Java Server SDK</description>

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.24</version>
+            <version>1.18.30</version>
             <scope>provided</scope>
         </dependency>
 
@@ -263,7 +263,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.4.0</version>
                 <executions>
                     <execution>
                         <id>add-source</id>

--- a/src/main/java/io/harness/cf/client/connector/FileWatcher.java
+++ b/src/main/java/io/harness/cf/client/connector/FileWatcher.java
@@ -1,6 +1,5 @@
 package io.harness.cf.client.connector;
 
-import com.sun.nio.file.SensitivityWatchEventModifier;
 import io.harness.cf.client.common.StringUtils;
 import io.harness.cf.client.dto.Message;
 import java.io.IOException;
@@ -26,12 +25,9 @@ class FileWatcher implements Runnable, AutoCloseable, Service {
     watcher = FileSystems.getDefault().newWatchService();
     path.register(
         watcher,
-        new WatchEvent.Kind[] {
-          StandardWatchEventKinds.ENTRY_CREATE,
-          StandardWatchEventKinds.ENTRY_DELETE,
-          StandardWatchEventKinds.ENTRY_MODIFY
-        },
-        SensitivityWatchEventModifier.HIGH);
+        StandardWatchEventKinds.ENTRY_CREATE,
+        StandardWatchEventKinds.ENTRY_DELETE,
+        StandardWatchEventKinds.ENTRY_MODIFY);
     log.info("FileWatcher initialized with path {}/{}", path, domain);
   }
 


### PR DESCRIPTION
[FFM-9691] - Add support for Java 21

What
Java 21 was released in Sep 2023 and is an LTS release. Update the relevant files.

Why
The current version of the Java SDK uses some APIs which are now deprecated (via lombok) and causes the build to fail on latest JDK.

Testing
Manual

[FFM-9691]: https://harness.atlassian.net/browse/FFM-9691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ