### PR TITLE
[FFM-9809] - Improved stream restart logic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -399,7 +399,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.8</version>
+                <version>0.8.11</version>
                 <executions>
                     <execution>
                         <id>default-prepare-agent</id>

--- a/src/main/java/io/harness/cf/client/api/InnerClient.java
+++ b/src/main/java/io/harness/cf/client/api/InnerClient.java
@@ -212,6 +212,11 @@ class InnerClient
       pollProcessor =
           new PollingProcessor(connector, repository, options.getPollIntervalInSeconds(), this);
       pollProcessor.start();
+
+      if (updateProcessor != null && options.isStreamEnabled()) {
+        updateProcessor.restart();
+      }
+
     } else {
       log.info(
           "Poller already running [closing={} interval={}]",

--- a/src/main/java/io/harness/cf/client/api/UpdateProcessor.java
+++ b/src/main/java/io/harness/cf/client/api/UpdateProcessor.java
@@ -149,4 +149,10 @@ class UpdateProcessor implements AutoCloseable {
     }
     log.info("UpdateProcessor closed");
   }
+
+  public void restart() {
+    log.info("Restart SSE stream");
+    stop();
+    start();
+  }
 }

--- a/src/main/java/io/harness/cf/client/api/UpdateProcessor.java
+++ b/src/main/java/io/harness/cf/client/api/UpdateProcessor.java
@@ -79,6 +79,11 @@ class UpdateProcessor implements AutoCloseable {
   }
 
   public void update(@NonNull final Message message) {
+    if (executor.isShutdown() || executor.isTerminated()) {
+      log.warn("Update processor is terminating/restarting. Update skipped: {}", message);
+      return;
+    }
+
     if (message.getDomain().equals("flag")) {
       log.debug("execute processFlag with message {}", message);
       executor.submit(processFlag(message));

--- a/src/main/java/io/harness/cf/client/common/Utils.java
+++ b/src/main/java/io/harness/cf/client/common/Utils.java
@@ -2,6 +2,9 @@ package io.harness.cf.client.common;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 
@@ -30,5 +33,13 @@ public class Utils {
       scheduler.shutdownNow();
       Thread.currentThread().interrupt();
     }
+  }
+
+  public static Map<String, String> redactHeaders(Map<String, String> hdrsMap) {
+    if (hdrsMap == null || hdrsMap.isEmpty()) return Collections.emptyMap();
+    HashMap<String, String> map = new HashMap<>(hdrsMap);
+    map.computeIfPresent("Authorization", (k, v) -> "*");
+    map.computeIfPresent("API-Key", (k, v) -> "*");
+    return map;
   }
 }

--- a/src/main/java/io/harness/cf/client/connector/EventSource.java
+++ b/src/main/java/io/harness/cf/client/connector/EventSource.java
@@ -189,7 +189,7 @@ public class EventSource implements Callback, AutoCloseable, Service {
       updater.onDisconnected("End of SSE stream");
     } catch (Throwable ex) {
       log.warn("SSE Stream aborted: " + ex.getMessage());
-      log.trace("SSE Stream aborted trace", ex);
+      log.error("SSE Stream aborted trace", ex);
       updater.onDisconnected(ex.getMessage());
     }
   }

--- a/src/main/java/io/harness/cf/client/connector/EventSource.java
+++ b/src/main/java/io/harness/cf/client/connector/EventSource.java
@@ -146,7 +146,9 @@ public class EventSource implements Callback, AutoCloseable, Service {
 
   public void close() {
     stop();
-    this.streamClient.connectionPool().evictAll();
+    if (this.streamClient != null) {
+      this.streamClient.connectionPool().evictAll();
+    }
     log.info("EventSource closed");
   }
 

--- a/src/main/java/io/harness/cf/client/connector/EventSource.java
+++ b/src/main/java/io/harness/cf/client/connector/EventSource.java
@@ -1,5 +1,7 @@
 package io.harness.cf.client.connector;
 
+import static io.harness.cf.client.common.Utils.redactHeaders;
+
 import com.google.gson.Gson;
 import io.harness.cf.client.common.SdkCodes;
 import io.harness.cf.client.dto.Message;
@@ -117,7 +119,7 @@ public class EventSource implements Callback, AutoCloseable, Service {
 
   @Override
   public void start() throws ConnectorException, InterruptedException {
-    log.info("EventSource connecting with url {} and headers {}", url, headers);
+    log.info("EventSource connecting with url {} and headers {}", url, redactHeaders(headers));
 
     this.streamClient = makeStreamClient(sseReadTimeoutMins, trustedCAs);
 
@@ -189,7 +191,7 @@ public class EventSource implements Callback, AutoCloseable, Service {
       updater.onDisconnected("End of SSE stream");
     } catch (Throwable ex) {
       log.warn("SSE Stream aborted: " + ex.getMessage());
-      log.error("SSE Stream aborted trace", ex);
+      log.trace("SSE Stream aborted trace", ex);
       updater.onDisconnected(ex.getMessage());
     }
   }

--- a/src/main/java/io/harness/cf/client/connector/EventSource.java
+++ b/src/main/java/io/harness/cf/client/connector/EventSource.java
@@ -183,15 +183,12 @@ public class EventSource implements Callback, AutoCloseable, Service {
           updater.update(msg);
         }
       }
-
-      throw new SSEStreamException("End of SSE stream");
+      log.warn("End of SSE stream");
+      updater.onDisconnected("End of SSE stream");
     } catch (Throwable ex) {
       log.warn("SSE Stream aborted: " + ex.getMessage());
+      log.trace("SSE Stream aborted trace", ex);
       updater.onDisconnected(ex.getMessage());
-      if (ex instanceof SSEStreamException) {
-        throw ex;
-      }
-      throw new SSEStreamException(ex.getMessage(), ex);
     }
   }
 

--- a/src/test/java/io/harness/cf/client/api/CfClientTest.java
+++ b/src/test/java/io/harness/cf/client/api/CfClientTest.java
@@ -667,7 +667,8 @@ class CfClientTest {
         assertTrue(success, "timeout waiting for /stream endpoint connections");
         assertTrue(
             dispatcher.streamCount.get() >= 2,
-            "no connection attempts to attempts to /stream endpoint");
+            "not enough connection attempts to attempts to /stream endpoint: "
+                + dispatcher.streamCount.get());
       }
     }
   }

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -10,7 +10,7 @@
     </appender>
 
     <logger name="io.harness.cf.client" level="INFO"/>
-
+    <logger name="io.harness.cf.client.api.MetricsProcessor" level="ERROR"/>
     <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>


### PR DESCRIPTION
[FFM-9809] - Adding additional tests for reset streams

What
Update EventSource to call onDisconnect() and add new logic to restart SSE. Adds another test to CfClientTest that will force a stream to drop during data transfer

Why
Additional assertions are useful for testing code paths

Testing
Unit test

[FFM-9809]: https://harness.atlassian.net/browse/FFM-9809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ