### PR TITLE
[FFM-9924] - Testgrid - % rollout - Java SDK - Fix MM3 hash

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.harness.featureflags</groupId>
     <artifactId>examples</artifactId>
-    <version>1.3.1</version>
+    <version>1.4.0</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>io.harness</groupId>
             <artifactId>ff-java-server-sdk</artifactId>
-            <version>1.3.1</version>
+            <version>1.4.0</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.harness</groupId>
     <artifactId>ff-java-server-sdk</artifactId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.4.0</version>
     <packaging>jar</packaging>
     <name>Harness Feature Flag Java Server SDK</name>
     <description>Harness Feature Flag Java Server SDK</description>

--- a/src/main/java/io/harness/cf/client/common/SdkCodes.java
+++ b/src/main/java/io/harness/cf/client/common/SdkCodes.java
@@ -71,6 +71,11 @@ public class SdkCodes {
     log.warn(sdkErrMsg(6001, of(msg)));
   }
 
+  public static void warnBucketByAttributeNotFound(String bucketBy, String usingValue) {
+    String msg = String.format("missing=%s, using value=%s", bucketBy, usingValue);
+    log.warn(sdkErrMsg(6002, of(msg)));
+  }
+
   private static final Map<Integer, String> MAP =
       Arrays.stream(
               new String[][] {
@@ -99,6 +104,10 @@ public class SdkCodes {
                 // SDK_EVAL_6xxx
                 {"6000", "Evaluated variation successfully"},
                 {"6001", "Default variation was served"},
+                {
+                  "6002",
+                  "BucketBy attribute not found in target attributes, falling back to 'identifier':"
+                },
                 // SDK_METRICS_7xxx
                 {"7000", "Metrics thread started, intervalMs:"},
                 {"7001", "Metrics thread exited"},

--- a/src/test/java/io/harness/cf/client/api/EvaluatorTest.java
+++ b/src/test/java/io/harness/cf/client/api/EvaluatorTest.java
@@ -44,15 +44,21 @@ public class EvaluatorTest {
   }
 
   @Test
+  public void checkBucket57IsMatchingCorrectly() {
+    int bucket = Evaluator.getNormalizedNumber("test", "identifier");
+    assertEquals(57, bucket);
+  }
+
+  @Test
   public void testPercentageRollout() throws URISyntaxException, IOException {
 
     // JSON has a weight distribution of 25%, 50%, 25%, 0%
 
-    testPercentageRolloutMatches("andrew.bell@harness.io", "variationB"); // 31
-    testPercentageRolloutMatches("nobody1@harness.io", "variationA"); // 19
-    testPercentageRolloutMatches("nobody2@harness.io", "variationB"); // 36
-    testPercentageRolloutMatches("nobody3@harness.io", "variationA"); // 12
-    testPercentageRolloutMatches("nobody4@harness.io", "variationC"); // 87
+    testPercentageRolloutMatches("nobody0@harness.io", "variationB"); // 36
+    testPercentageRolloutMatches("nobody1@harness.io", "variationA"); // 10
+    testPercentageRolloutMatches("nobody2@harness.io", "variationA"); // 17
+    testPercentageRolloutMatches("nobody3@harness.io", "variationA"); // 15
+    testPercentageRolloutMatches("nobody4@harness.io", "variationC"); // 86
   }
 
   private void testPercentageRolloutMatches(String targetIdentifier, String expectedVariant)
@@ -93,10 +99,7 @@ public class EvaluatorTest {
   @Test
   public void shouldReturnFalseWhenClauseEmptyOrInvalid() {
     final Target target =
-        Target.builder()
-            .identifier("andrew.bell@harness.io")
-            .name("andrew.bell@harness.io")
-            .build();
+        Target.builder().identifier("testuser@harness.io").name("testuser@harness.io").build();
     assertFalse(evaluator.evaluateClause(null, target));
 
     Clause mockClause = mock(Clause.class);
@@ -116,13 +119,13 @@ public class EvaluatorTest {
 
   @Test
   public void shouldEvaluateOperatorClauseCorrectly() {
-    evaluateOperatorClause("andrew.bell@harness.io", STARTS_WITH, "andrew");
-    evaluateOperatorClause("andrew.bell@harness.io", ENDS_WITH, ".io");
-    evaluateOperatorClause("andrew.bell@harness.io", MATCH, ".*harness.*");
-    evaluateOperatorClause("andrew.bell@harness.io", CONTAINS, "bell");
-    evaluateOperatorClause("andrew.bell@harness.io", EQUAL, "Andrew.Bell@Harness.IO");
-    evaluateOperatorClause("andrew.bell@harness.io", EQUAL_SENSITIVE, "andrew.bell@harness.io");
-    evaluateOperatorClause("andrew", IN, "andrew,bell,harness,io");
+    evaluateOperatorClause("testuser@harness.io", STARTS_WITH, "testuser");
+    evaluateOperatorClause("testuser@harness.io", ENDS_WITH, ".io");
+    evaluateOperatorClause("testuser@harness.io", MATCH, ".*harness.*");
+    evaluateOperatorClause("testuser@harness.io", CONTAINS, "user");
+    evaluateOperatorClause("testuser@harness.io", EQUAL, "testuser@Harness.IO");
+    evaluateOperatorClause("testuser@harness.io", EQUAL_SENSITIVE, "testuser@harness.io");
+    evaluateOperatorClause("abc", IN, "abc,def,harness,io");
   }
 
   @Test
@@ -156,10 +159,7 @@ public class EvaluatorTest {
   @Test
   public void shouldReturnFalseWhenGetAttrValueEmptyOrInvalid() {
     Target target =
-        Target.builder()
-            .identifier("andrew.bell@harness.io")
-            .name("andrew.bell@harness.io")
-            .build();
+        Target.builder().identifier("testuser@harness.io").name("testuser@harness.io").build();
 
     assertFalse(evaluator.getAttrValue(target, "").isPresent());
     assertFalse(evaluator.getAttrValue(null, "notempty").isPresent());
@@ -172,9 +172,9 @@ public class EvaluatorTest {
 
   @Test
   public void shouldReturnCorrectAttrForGetAttrValue() {
-    Target target = Target.builder().identifier("andrew.bell@harness.io").name("andrew").build();
+    Target target = Target.builder().identifier("testuser@harness.io").name("andrew").build();
 
-    assertEquals("andrew.bell@harness.io", evaluator.getAttrValue(target, "identifier").get());
+    assertEquals("testuser@harness.io", evaluator.getAttrValue(target, "identifier").get());
     assertEquals("andrew", evaluator.getAttrValue(target, "name").get());
   }
 


### PR DESCRIPTION
[FFM-9924] - Testgrid - % rollout - Java SDK - Fix MM3 hash

**What**
Various fixes to MM3 hash to bring it in alignment with GoLang SDK
- Set MM3 seed to 0
- If bucket_by attribute is missing, fall back to identifier + log new SDK code
- Additional debug statements for easier diagnostics
- Update unit tests

**Why**
Review SDKs to make sure Murmur3 hash calculations are consistent across SDKs and buckets mappings align for customers that rely on this feature.

**Testing**
New percentage rollout tests added to testgrid, these will be committed later

[FFM-9924]: https://harness.atlassian.net/browse/FFM-9924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ