### PR TITLE
[FFM-10136] - Drop SSE event log down from INFO to DEBUG

### DIFF
--- a/src/main/java/io/harness/cf/client/connector/EventSource.java
+++ b/src/main/java/io/harness/cf/client/connector/EventSource.java
@@ -179,7 +179,7 @@ public class EventSource implements Callback, AutoCloseable, Service {
 
       String line;
       while ((line = reader.readUtf8Line()) != null) {
-        log.info("SSE stream data: {}", line);
+        log.debug("SSE stream data: {}", line);
 
         if (line.startsWith("data:")) {
           Message msg = gson.fromJson(line.substring(6), Message.class);


### PR DESCRIPTION
[FFM-10136] - Drop SSE event log down from INFO to DEBUG

**What**
Change SSE event log from INFO to DEBUG

**Why**
Remove excessive logging at INFO level

**Testing**
Manual

[FFM-10136]: https://harness.atlassian.net/browse/FFM-10136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ