### PR TITLE
FFM-10355 - Remove maven-model

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,6 @@ allprojects {
 dependencies {
     api libs.okhttp3.core
     api libs.okhttp3.logging.interceptor
-    api libs.apache.maven.model
     api libs.apache.commons.collections4
     api libs.threetenbp
     api libs.gson.fire

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,7 +10,6 @@ dependencyResolutionManagement {
             version('okhttp3', '4.9.3')
             library('okhttp3-core', 'com.squareup.okhttp3', 'okhttp').versionRef('okhttp3')
             library('okhttp3-logging-interceptor', 'com.squareup.okhttp3', 'logging-interceptor').versionRef('okhttp3')
-            library('apache-maven-model', 'org.apache.maven:maven-model:3.5.0')
             library('threetenbp', 'org.threeten:threetenbp:1.4.3')
             library('gson-fire', 'io.gsonfire:gson-fire:1.7.1')
             library('google-gson', 'com.google.code.gson:gson:2.10')


### PR DESCRIPTION
FFM-10355 - Remove maven-model

**What**
Remove maven-model and its dependencies to save approx 871 KB

commons-lang3-3.5.jar   468.63 KB
plexus-utils-3.0.24.jar 241.55 KB
maven-model-3.5.0.jar   161.15 KB

**Why**
We only use the class `ImmutablePair` from commons-lang3 which can be easily re-implemented

**Testing**
Manual + testgrid