### PR TITLE
FFM-10363 - Upgrade okhttp and fix CVE-2023-3635, CVE-2022-24329 & CVE-2020-29582

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -250,6 +250,10 @@ spotless {
     }
 }
 
+dependencyCheck {
+    formats = [ "HTML", "JSON" ]
+}
+
 compileJava.dependsOn tasks.openApiGenerate
 compileJava.dependsOn generateVersion
 compileJava.dependsOn spotlessApply

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,7 +7,7 @@ dependencyResolutionManagement {
             version('sdk', '1.5.0');
 
             // sdk deps
-            version('okhttp3', '4.9.3')
+            version('okhttp3', '4.12.0')
             library('okhttp3-core', 'com.squareup.okhttp3', 'okhttp').versionRef('okhttp3')
             library('okhttp3-logging-interceptor', 'com.squareup.okhttp3', 'logging-interceptor').versionRef('okhttp3')
             library('gson-fire', 'io.gsonfire:gson-fire:1.7.1')


### PR DESCRIPTION
FFM-10363 - Upgrade okhttp and fix CVE-2023-3635, CVE-2022-24329 & CVE-2020-29582

**What**
Upgrade okhttp to 4.12.0

**Why**
The following dependencies have CVEs: `kotlin-stdlib-1.4.10.jar` and `okio-2.8.0.jar` these are brough in by okhttp 4.9.3, we should upgrade to 4.12.0

https://nvd.nist.gov/vuln/detail/CVE-2023-3635
https://nvd.nist.gov/vuln/detail/CVE-2022-24329
https://nvd.nist.gov/vuln/detail/CVE-2020-29582

**Testing**
Manual + testgrid