### PR TITLE
FFM-10366 - Delete events throwing ApiException exception

### DIFF
--- a/src/main/java/io/harness/cf/client/api/UpdateProcessor.java
+++ b/src/main/java/io/harness/cf/client/api/UpdateProcessor.java
@@ -99,15 +99,15 @@ class UpdateProcessor implements AutoCloseable {
 
     return () -> {
       try {
-        final FeatureConfig config = connector.getFlag(message.getIdentifier());
-        if (config != null) {
-          if (message.getEvent().equals("create") || message.getEvent().equals("patch")) {
+        if (message.getEvent().equals("create") || message.getEvent().equals("patch")) {
+          final FeatureConfig config = connector.getFlag(message.getIdentifier());
+          if (config != null) {
             repository.setFlag(message.getIdentifier(), config);
             log.debug("Set new segment with key {} and value {}", message.getIdentifier(), config);
-          } else if (message.getEvent().equals("delete")) {
-            log.debug("Delete flag with key {}", message.getIdentifier());
-            repository.deleteFlag(message.getIdentifier());
           }
+        } else if (message.getEvent().equals("delete")) {
+          log.debug("Delete flag with key {}", message.getIdentifier());
+          repository.deleteFlag(message.getIdentifier());
         }
       } catch (ConnectorException e) {
         log.error(
@@ -121,15 +121,15 @@ class UpdateProcessor implements AutoCloseable {
   protected Runnable processSegment(@NonNull final Message message) {
     return () -> {
       try {
-        final Segment segment = connector.getSegment(message.getIdentifier());
-        if (segment != null) {
-          if (message.getEvent().equals("create") || message.getEvent().equals("patch")) {
+        if (message.getEvent().equals("create") || message.getEvent().equals("patch")) {
+          final Segment segment = connector.getSegment(message.getIdentifier());
+          if (segment != null) {
             log.debug("Set new segment with key {} and value {}", message.getIdentifier(), segment);
             repository.setSegment(message.getIdentifier(), segment);
-          } else if (message.getEvent().equals("delete")) {
-            log.debug("Delete segment with key {}", message.getIdentifier());
-            repository.deleteSegment(message.getIdentifier());
           }
+        } else if (message.getEvent().equals("delete")) {
+          log.debug("Delete segment with key {}", message.getIdentifier());
+          repository.deleteSegment(message.getIdentifier());
         }
       } catch (ConnectorException e) {
         log.error(

--- a/src/main/java/io/harness/cf/client/connector/ConnectorException.java
+++ b/src/main/java/io/harness/cf/client/connector/ConnectorException.java
@@ -21,6 +21,13 @@ public class ConnectorException extends Exception {
     this.shouldRetry = true;
   }
 
+  public ConnectorException(String message, int httpCode, String httpMsg, Exception e) {
+    super(message, e);
+    this.httpCode = httpCode;
+    this.httpReason = httpMsg;
+    this.shouldRetry = true;
+  }
+
   public ConnectorException(String message, boolean shouldRetry, Exception e) {
     super(message, e);
     this.shouldRetry = shouldRetry;

--- a/src/main/java/io/harness/cf/client/connector/HarnessConnector.java
+++ b/src/main/java/io/harness/cf/client/connector/HarnessConnector.java
@@ -255,7 +255,7 @@ public class HarnessConnector implements Connector, AutoCloseable {
           this.environmentUuid,
           this.cluster,
           e);
-      throw new ConnectorException(e.getMessage(), e.getCode(), e.getMessage());
+      throw new ConnectorException(e.getMessage(), e.getCode(), e.getMessage(), e);
     } finally {
       MDC.remove(REQUEST_ID_KEY);
     }
@@ -283,7 +283,7 @@ public class HarnessConnector implements Connector, AutoCloseable {
           this.environmentUuid,
           this.cluster,
           e);
-      throw new ConnectorException(e.getMessage(), e.getCode(), e.getMessage());
+      throw new ConnectorException(e.getMessage(), e.getCode(), e.getMessage(), e);
     } finally {
       MDC.remove(REQUEST_ID_KEY);
     }
@@ -314,7 +314,7 @@ public class HarnessConnector implements Connector, AutoCloseable {
           e.getCode(),
           e.getMessage(),
           e);
-      throw new ConnectorException(e.getMessage(), e.getCode(), e.getMessage());
+      throw new ConnectorException(e.getMessage(), e.getCode(), e.getMessage(), e);
     } finally {
       MDC.remove(REQUEST_ID_KEY);
     }
@@ -345,7 +345,7 @@ public class HarnessConnector implements Connector, AutoCloseable {
           this.environmentUuid,
           this.cluster,
           e);
-      throw new ConnectorException(e.getMessage(), e.getCode(), e.getMessage());
+      throw new ConnectorException(e.getMessage(), e.getCode(), e.getMessage(), e);
     } finally {
       MDC.remove(REQUEST_ID_KEY);
     }
@@ -369,7 +369,7 @@ public class HarnessConnector implements Connector, AutoCloseable {
           this.environmentUuid,
           this.cluster,
           e);
-      throw new ConnectorException(e.getMessage(), e.getCode(), e.getMessage());
+      throw new ConnectorException(e.getMessage(), e.getCode(), e.getMessage(), e);
     } finally {
       MDC.remove(REQUEST_ID_KEY);
     }

--- a/src/test/java/io/harness/cf/client/api/UpdateProcessorTest.java
+++ b/src/test/java/io/harness/cf/client/api/UpdateProcessorTest.java
@@ -1,0 +1,43 @@
+package io.harness.cf.client.api;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.harness.cf.client.connector.Connector;
+import io.harness.cf.client.connector.ConnectorException;
+import io.harness.cf.client.connector.Updater;
+import io.harness.cf.client.dto.Message;
+import org.junit.jupiter.api.Test;
+
+public class UpdateProcessorTest {
+
+  @Test
+  public void shouldNotCallOutToServerOnDeleteTargetSegmentEvent() throws ConnectorException {
+    final Connector mockConnector = mock(Connector.class);
+    final Repository mockRepo = mock(Repository.class);
+    final Updater mockUpdater = mock(Updater.class);
+
+    final UpdateProcessor processor = new UpdateProcessor(mockConnector, mockRepo, mockUpdater);
+    final Message message = new Message("delete", "target-segment", "test", 1);
+    processor.processSegment(message).run();
+
+    verify(mockConnector, times(0)).getSegment(anyString());
+    verify(mockRepo, times(1)).deleteSegment(anyString());
+  }
+
+  @Test
+  public void shouldNotCallOutToServerOnDeleteFlagEvent() throws ConnectorException {
+    final Connector mockConnector = mock(Connector.class);
+    final Repository mockRepo = mock(Repository.class);
+    final Updater mockUpdater = mock(Updater.class);
+
+    final UpdateProcessor processor = new UpdateProcessor(mockConnector, mockRepo, mockUpdater);
+    final Message message = new Message("delete", "flag", "test", 1);
+    processor.processFlag(message).run();
+
+    verify(mockConnector, times(0)).getFlag(anyString());
+    verify(mockRepo, times(1)).deleteFlag(anyString());
+  }
+}


### PR DESCRIPTION
FFM-10366 - Delete events throwing ApiException exception

**What**
Delete events don't need to call out to the server since they're only a notification to remove a flag/segment from local cache.

**Why**
When deleting a flag or target segment the following exception is seen:

```
io.harness.cf.ApiException:
	at io.harness.cf.ApiClient.handleResponse(ApiClient.java:1079)
	at io.harness.cf.ApiClient.execute(ApiClient.java:992)
	at io.harness.cf.api.ClientApi.getSegmentByIdentifierWithHttpInfo(ClientApi.java:1087)
	at io.harness.cf.api.ClientApi.getSegmentByIdentifier(ClientApi.java:1062)
	at io.harness.cf.client.connector.HarnessConnector.getSegment(HarnessConnector.java:334)
	at io.harness.cf.client.api.UpdateProcessor.lambda$processSegment$1(UpdateProcessor.java:124)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
```

It is caused by a 404 being returned by the server

**Testing**
Manual + testgrid