### PR TITLE
[FFM-10760] - Use a single ExecutorService for UpdateProcessor

### DIFF
--- a/examples/src/main/java/io/harness/ff/examples/GettingStarted.java
+++ b/examples/src/main/java/io/harness/ff/examples/GettingStarted.java
@@ -9,19 +9,18 @@ import java.util.concurrent.TimeUnit;
 
 public class GettingStarted {
     // API Key - set this as an env variable
-    private static String apiKey = getEnvOrDefault("FF_API_KEY", "");
+    private static final String apiKey = getEnvOrDefault("FF_API_KEY", "");
 
     // Flag Identifier
-    private static String flagName = getEnvOrDefault("FF_FLAG_NAME", "harnessappdemodarkmode");
+    private static final String flagName = getEnvOrDefault("FF_FLAG_NAME", "harnessappdemodarkmode");
 
     private static final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
 
     public static void main(String[] args) {
         System.out.println("Harness SDK Getting Started");
 
-        try {
-            //Create a Feature Flag Client
-            CfClient cfClient = new CfClient(apiKey, BaseConfig.builder().build());
+        //Create a Feature Flag Client
+        try (CfClient cfClient = new CfClient(apiKey, BaseConfig.builder().build())) {
             cfClient.waitForInitialization();
 
             // Create a target (different targets can get different results based on rules.  This includes a custom attribute 'location')
@@ -46,7 +45,6 @@ public class GettingStarted {
             // Close the SDK
             System.out.println("Cleaning up...");
             scheduler.shutdownNow();
-            cfClient.close();
 
         } catch (Exception e) {
             e.printStackTrace();

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,7 +4,7 @@ dependencyResolutionManagement {
     versionCatalogs {
         libs {
             // main sdk version
-            version('sdk', '1.5.2');
+            version('sdk', '1.5.1');
 
             // sdk deps
             version('okhttp3', '4.12.0')

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,7 +4,7 @@ dependencyResolutionManagement {
     versionCatalogs {
         libs {
             // main sdk version
-            version('sdk', '1.5.1');
+            version('sdk', '1.5.2');
 
             // sdk deps
             version('okhttp3', '4.12.0')

--- a/src/main/java/io/harness/cf/client/api/CaffeineCache.java
+++ b/src/main/java/io/harness/cf/client/api/CaffeineCache.java
@@ -20,13 +20,13 @@ public class CaffeineCache implements Cache {
 
   public CaffeineCache(int size) {
     cache = Caffeine.newBuilder().maximumSize(size).build();
-    log.debug("CaffeineCache initialized with size {}", size);
+    log.trace("CaffeineCache initialized with size {}", size);
   }
 
   @Override
   public void set(@NonNull String key, @NonNull Object value) {
     cache.put(key, value);
-    log.debug("New value in the cache with key {} and value {}", key, value);
+    log.trace("New value in the cache with key '{}' and value '{}'", key, value);
   }
 
   @Override
@@ -34,9 +34,9 @@ public class CaffeineCache implements Cache {
   public Object get(@NonNull String key) {
     Object value = cache.getIfPresent(key);
     if (value != null) {
-      log.debug("Key {} found in cache with value {}", key, value);
+      log.trace("Key '{}' found in cache with value '{}'", key, value);
     } else {
-      log.debug("Key {} not found in cache", key);
+      log.trace("Key '{}' not found in cache", key);
     }
     return value;
   }
@@ -44,13 +44,13 @@ public class CaffeineCache implements Cache {
   @Override
   public void delete(@NonNull String key) {
     cache.invalidate(key);
-    log.debug("Key {} removed from cache", key);
+    log.trace("Key {} removed from cache", key);
   }
 
   @Override
   public List<String> keys() {
     List<String> keys = new ArrayList<>(cache.asMap().keySet());
-    log.debug("Keys in cache {}", keys);
+    log.trace("Keys in cache {}", keys);
     return keys;
   }
 }

--- a/src/main/java/io/harness/cf/client/api/Evaluator.java
+++ b/src/main/java/io/harness/cf/client/api/Evaluator.java
@@ -60,7 +60,7 @@ public class Evaluator implements Evaluation {
     }
     Optional<Variation> variation =
         variations.stream().filter(v -> v.getIdentifier().equals(identifier)).findFirst();
-    log.debug("Variation {} found in variations {}", identifier, variations);
+    log.trace("Variation {} found in variations {}", identifier, variations);
     return variation;
   }
 

--- a/src/main/java/io/harness/cf/client/connector/EventSource.java
+++ b/src/main/java/io/harness/cf/client/connector/EventSource.java
@@ -190,10 +190,16 @@ public class EventSource implements Callback, AutoCloseable, Service {
       log.warn("End of SSE stream");
       updater.onDisconnected("End of SSE stream");
     } catch (Throwable ex) {
-      log.warn("SSE Stream aborted: " + ex.getMessage());
+      log.warn("SSE Stream aborted: " + getExceptionMsg(ex));
       log.trace("SSE Stream aborted trace", ex);
-      updater.onDisconnected(ex.getMessage());
+      updater.onDisconnected(getExceptionMsg(ex));
     }
+  }
+
+  private String getExceptionMsg(Throwable ex) {
+    return (ex.getMessage() == null || "null".equals(ex.getMessage()))
+        ? ex.getClass().getSimpleName()
+        : ex.getMessage();
   }
 
   private static class SSEStreamException extends RuntimeException {

--- a/src/main/java/io/harness/cf/client/connector/HarnessConnector.java
+++ b/src/main/java/io/harness/cf/client/connector/HarnessConnector.java
@@ -404,7 +404,7 @@ public class HarnessConnector implements Connector, AutoCloseable {
             map,
             updater,
             Math.max(options.getSseReadTimeout(), 1),
-            2_000,
+            ThreadLocalRandom.current().nextInt(5000, 10000),
             options.getTlsTrustedCAs());
     return eventSource;
   }


### PR DESCRIPTION
**What**
- Change UpdateProcessor to use a single thread pool for the life time of the service
- Updated `processFlag()` and `processSegment()` to catch `Throwable` to prevent executor threads dying
- Drop some verbose logs to trace to make debug level more readable

**Why**
We are getting reports in the field that the following error message is being logged

`Update processor is terminating/restarting. Update skipped: <EVENT JSON>`

Looking at the code this can only happen if the SSE stream drops and we attempt to call `restart()` while events are still arriving from the old stream. We should modify the code to avoid creating/destroying the thread pool on each disconnect and instead use a single thread pool for the lifetime of the UpdateProcessor which is only destroyed when `close()` is called. This will allow the removal of the following defensive check and will help avoid dropping SSE messages that did make it before the disconnect:

```
   if (executor.isShutdown() || executor.isTerminated()) {
      log.warn("Update processor is terminating/restarting. Update skipped: {}", message);
      return;
   }
```