### PR TITLE
[FFM-10816] - Remove metrics flush on map overflow

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -4,7 +4,7 @@ dependencyResolutionManagement {
     versionCatalogs {
         libs {
             // main sdk version
-            version('sdk', '1.5.1');
+            version('sdk', '1.5.2');
 
             // sdk deps
             version('okhttp3', '4.12.0')

--- a/src/main/java/io/harness/cf/client/api/BaseConfig.java
+++ b/src/main/java/io/harness/cf/client/api/BaseConfig.java
@@ -27,7 +27,7 @@ public class BaseConfig {
   @Getter(AccessLevel.NONE)
   private final int frequency = 60; // unit: second
 
-  @Builder.Default private final int bufferSize = 2048;
+  @Builder.Default private final int bufferSize = 5000;
 
   // Flag to set all attributes as private
   @Deprecated @Builder.Default private final boolean allAttributesPrivate = false;

--- a/src/main/java/io/harness/cf/client/api/MetricsProcessor.java
+++ b/src/main/java/io/harness/cf/client/api/MetricsProcessor.java
@@ -96,8 +96,8 @@ class MetricsProcessor {
   private static final Target globalTarget =
       Target.builder().name(GLOBAL_TARGET_NAME).identifier(GLOBAL_TARGET).build();
 
-  private final static int MAX_SENT_TARGETS_TO_RETAIN = 100_000;
-  private final static int MAX_FREQ_MAP_TO_RETAIN = 10_000;
+  private static final int MAX_SENT_TARGETS_TO_RETAIN = 100_000;
+  private static final int MAX_FREQ_MAP_TO_RETAIN = 10_000;
   private final Connector connector;
   private final BaseConfig config;
   private final FrequencyMap<MetricEvent> frequencyMap;
@@ -115,7 +115,10 @@ class MetricsProcessor {
     this.config = config;
     this.frequencyMap = new FrequencyMap<>();
     this.targetsSeen = ConcurrentHashMap.newKeySet();
-    this.maxFreqMapSize = (config.getBufferSize() > MAX_FREQ_MAP_TO_RETAIN) ? MAX_FREQ_MAP_TO_RETAIN : config.getBufferSize();
+    this.maxFreqMapSize =
+        (config.getBufferSize() > MAX_FREQ_MAP_TO_RETAIN)
+            ? MAX_FREQ_MAP_TO_RETAIN
+            : config.getBufferSize();
     callback.onMetricsReady();
   }
 

--- a/src/main/java/io/harness/cf/client/common/SdkCodes.java
+++ b/src/main/java/io/harness/cf/client/common/SdkCodes.java
@@ -65,6 +65,12 @@ public class SdkCodes {
     log.warn(sdkErrMsg(7002, Optional.ofNullable(reason)));
   }
 
+
+  public static void warnMetricsBufferFull() {
+    log.warn(sdkErrMsg(7008, Optional.empty()));
+  }
+
+
   public static void warnDefaultVariationServed(String identifier, Target target, String def) {
     String targetId = (target == null) ? "null" : target.getIdentifier();
     String msg = String.format("identifier=%s, target=%s, default=%s", identifier, targetId, def);
@@ -111,7 +117,9 @@ public class SdkCodes {
                 // SDK_METRICS_7xxx
                 {"7000", "Metrics thread started, intervalMs:"},
                 {"7001", "Metrics thread exited"},
-                {"7002", "Posting metrics failed, reason:"}
+                {"7002", "Posting metrics failed, reason:"},
+                {"7008", "Metrics buffer is full and metrics will be discarded"}
+
               })
           .collect(Collectors.toMap(entry -> Integer.parseInt(entry[0]), entry -> entry[1]));
 

--- a/src/main/java/io/harness/cf/client/common/SdkCodes.java
+++ b/src/main/java/io/harness/cf/client/common/SdkCodes.java
@@ -65,11 +65,9 @@ public class SdkCodes {
     log.warn(sdkErrMsg(7002, Optional.ofNullable(reason)));
   }
 
-
   public static void warnMetricsBufferFull() {
     log.warn(sdkErrMsg(7008, Optional.empty()));
   }
-
 
   public static void warnDefaultVariationServed(String identifier, Target target, String def) {
     String targetId = (target == null) ? "null" : target.getIdentifier();
@@ -119,7 +117,6 @@ public class SdkCodes {
                 {"7001", "Metrics thread exited"},
                 {"7002", "Posting metrics failed, reason:"},
                 {"7008", "Metrics buffer is full and metrics will be discarded"}
-
               })
           .collect(Collectors.toMap(entry -> Integer.parseInt(entry[0]), entry -> entry[1]));
 

--- a/src/main/java/io/harness/cf/client/common/SdkCodes.java
+++ b/src/main/java/io/harness/cf/client/common/SdkCodes.java
@@ -65,8 +65,12 @@ public class SdkCodes {
     log.warn(sdkErrMsg(7002, Optional.ofNullable(reason)));
   }
 
-  public static void warnMetricsBufferFull() {
-    log.warn(sdkErrMsg(7008, Optional.empty()));
+  public static void warnMetricsBufferFull(long droppedEvals, long droppedTargets) {
+    log.warn(
+        sdkErrMsg(
+            7008,
+            Optional.of(
+                "- evals dropped: " + droppedEvals + " targets dropped: " + droppedTargets)));
   }
 
   public static void warnDefaultVariationServed(String identifier, Target target, String def) {

--- a/src/test/java/io/harness/cf/client/api/MetricsProcessorTest.java
+++ b/src/test/java/io/harness/cf/client/api/MetricsProcessorTest.java
@@ -34,8 +34,7 @@ public class MetricsProcessorTest implements MetricsCallback {
     MockitoAnnotations.openMocks(this);
     metricsProcessor =
         Mockito.spy(
-            new MetricsProcessor(
-                connector, BaseConfig.builder().bufferSize(BUFFER_SIZE).build(), this));
+            new MetricsProcessor(connector, BaseConfig.builder().bufferSize(10_001).build(), this));
 
     metricsProcessor.reset();
   }

--- a/src/test/java/io/harness/cf/client/api/MetricsProcessorTest.java
+++ b/src/test/java/io/harness/cf/client/api/MetricsProcessorTest.java
@@ -78,7 +78,7 @@ public class MetricsProcessorTest implements MetricsCallback {
           Variation variation =
               Variation.builder().identifier("true" + v).name("name" + v).value("true").build();
 
-          metricsProcessor.pushToQueue(target, feature.getFeature(), variation);
+          metricsProcessor.registerEvaluation(target, feature.getFeature(), variation);
 
           maxQueueMapSize = Math.max(maxQueueMapSize, metricsProcessor.getQueueSize());
           maxUniqueTargetSetSize =
@@ -88,13 +88,14 @@ public class MetricsProcessorTest implements MetricsCallback {
 
       if (t % 10 == 0) {
         log.info(
-            "Metrics frequency map (cur: {} max: {}) Unique targets (cur: {} max: {}) Events sent ({}) Events pending ({})",
+            "Metrics frequency map (cur: {} max: {}) Unique targets (cur: {} max: {}) Events sent ({}) Events pending ({}) Dropped ({})",
             metricsProcessor.getQueueSize(),
             maxQueueMapSize,
             metricsProcessor.getTargetSetSize(),
             maxUniqueTargetSetSize,
             metricsProcessor.getMetricsSent(),
-            metricsProcessor.getPendingMetricsToBeSent());
+            metricsProcessor.getPendingMetricsToBeSent(),
+            metricsProcessor.getMetricsEvalsDropped());
 
         metricsProcessor.flushQueue(); // mimic scheduled job
       }


### PR DESCRIPTION
[FFM-10816] - Remove metrics flush on map overflow

**What**
When too many evaluations are processed and with enough targets the internal metrics map we use will hit its limit very quickly. This causes the metrics to be flushed to the server.

**Why**
Flushing metrics is unbound and can result in more pressure on the server than necessary

**Testing**
Manual + unit

[FFM-10816]: https://harness.atlassian.net/browse/FFM-10816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ