### PR TITLE
[FFM-10981] - Update Java SDK example to include a delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,14 +78,14 @@ Add the following Maven dependency in your project's pom.xml file:
 <dependency>
     <groupId>io.harness</groupId>
     <artifactId>ff-java-server-sdk</artifactId>
-    <version>1.5.0</version>
+    <version>1.5.2</version>
 </dependency>
 ```
 
 #### Gradle
 
 ```
-implementation 'io.harness:ff-java-server-sdk:1.5.0'
+implementation 'io.harness:ff-java-server-sdk:1.5.2'
 ```
 
 ### Code Sample
@@ -116,7 +116,8 @@ public class GettingStarted {
     public static void main(String[] args) {
         System.out.println("Harness SDK Getting Started");
 
-        //Create a Feature Flag Client
+        // Create a Feature Flag Client
+        // try-with-resources is used here to automatically close the client when this block is exited
         try (CfClient cfClient = new CfClient(apiKey)) {
             cfClient.waitForInitialization();
 
@@ -136,6 +137,9 @@ public class GettingStarted {
                     0,
                     10,
                     TimeUnit.SECONDS);
+
+            // SDK will exit after 15 minutes, this gives the example time to stream events
+            TimeUnit.MINUTES.sleep(15);
 
         } catch (Exception e) {
             e.printStackTrace();
@@ -157,7 +161,6 @@ public class GettingStarted {
 
 ```bash
 export FF_API_KEY=<your key here>
-cd examples
 
 ./gradlew clean build
 ./gradlew examples:GettingStarted --console=plain

--- a/examples/src/main/java/io/harness/ff/examples/GettingStarted.java
+++ b/examples/src/main/java/io/harness/ff/examples/GettingStarted.java
@@ -26,7 +26,8 @@ public class GettingStarted {
                 //.eventUrl("http://localhost:8001/api/1.0")
                 .build());
 
-        //Create a Feature Flag Client
+        // Create a Feature Flag Client
+        // try-with-resources is used here to automatically close the client when this block is exited
         try (CfClient cfClient = new CfClient(connector)) {
             cfClient.waitForInitialization();
 
@@ -46,7 +47,7 @@ public class GettingStarted {
                     10,
                     TimeUnit.SECONDS);
 
-
+            // SDK will exit after 15 minutes, this gives the example time to stream events
             TimeUnit.MINUTES.sleep(15);
 
             // Close the SDK


### PR DESCRIPTION
[FFM-10981] - Update Java SDK example to include a delay

**What**
The example on the main page is missing a `sleep()` statement that is included in the code example. This updates the main page to match the example code.

**Why**
Help avoid confusion around the life cycle of the SDK - the current example will exit immediately which is not what we want.

[FFM-10981]: https://harness.atlassian.net/browse/FFM-10981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ