### PR TITLE
FFM-11356 - Add new query parameter to target-segments

### DIFF
--- a/src/main/java/io/harness/cf/client/connector/HarnessConnector.java
+++ b/src/main/java/io/harness/cf/client/connector/HarnessConnector.java
@@ -299,7 +299,7 @@ public class HarnessConnector implements Connector, AutoCloseable {
         this.cluster);
     List<Segment> allSegments = new ArrayList<>();
     try {
-      allSegments = api.getAllSegments(environmentUuid, cluster);
+      allSegments = api.getAllSegments(environmentUuid, cluster, "v2");
       log.debug(
           "Total target groups fetched: {} on env {} and cluster {}",
           allSegments.size(),
@@ -331,7 +331,7 @@ public class HarnessConnector implements Connector, AutoCloseable {
         this.cluster);
     try {
       Segment segmentByIdentifier =
-          api.getSegmentByIdentifier(identifier, environmentUuid, cluster);
+          api.getSegmentByIdentifier(identifier, environmentUuid, cluster, "v2");
       log.debug(
           "Segment {} successfully fetched from env {} and cluster {}",
           identifier,

--- a/src/main/resources/client-v1.yaml
+++ b/src/main/resources/client-v1.yaml
@@ -87,6 +87,7 @@ paths:
           schema:
             type: string
         - $ref: '#/components/parameters/clusterQueryOptionalParam'
+        - $ref: '#/components/parameters/segmentRulesV2QueryParam'
       security:
         - BearerAuth: []
       responses:
@@ -127,6 +128,7 @@ paths:
           schema:
             type: string
         - $ref: '#/components/parameters/clusterQueryOptionalParam'
+        - $ref: '#/components/parameters/segmentRulesV2QueryParam'
       security:
         - BearerAuth: []
       responses:
@@ -950,6 +952,17 @@ components:
       in: query
       required: false
       description: Unique identifier for the cluster for the account
+      schema:
+        type: string
+    segmentRulesV2QueryParam:
+      name: rules
+      in: query
+      required: false
+      description: >-
+        When set to rules=v2 will return AND rule compatible serving_rules
+        field. When not set or set to any other value will return old rules
+        field only compatible with OR rules.
+      allowEmptyValue: true
       schema:
         type: string
     environmentPathParam:

--- a/src/test/java/io/harness/cf/client/api/dispatchers/Endpoints.java
+++ b/src/test/java/io/harness/cf/client/api/dispatchers/Endpoints.java
@@ -6,7 +6,7 @@ public class Endpoints {
   public static final String FEATURES_ENDPOINT =
       "/api/1.0/client/env/00000000-0000-0000-0000-000000000000/feature-configs?cluster=1";
   public static final String SEGMENTS_ENDPOINT =
-      "/api/1.0/client/env/00000000-0000-0000-0000-000000000000/target-segments?cluster=1";
+      "/api/1.0/client/env/00000000-0000-0000-0000-000000000000/target-segments?cluster=1&rules=v2";
   public static final String STREAM_ENDPOINT = "/api/1.0/stream?cluster=1";
   public static final String SIMPLE_BOOL_FLAG_ENDPOINT =
       "/api/1.0/client/env/00000000-0000-0000-0000-000000000000/feature-configs/simplebool?cluster=1";

--- a/src/test/java/io/harness/cf/client/api/dispatchers/TestWebServerDispatcher.java
+++ b/src/test/java/io/harness/cf/client/api/dispatchers/TestWebServerDispatcher.java
@@ -27,7 +27,7 @@ public class TestWebServerDispatcher extends Dispatcher {
         return makeAuthResponse();
       case "/api/1.0/client/env/00000000-0000-0000-0000-000000000000/feature-configs?cluster=1":
         return makeMockJsonResponse(200, makeBasicFeatureJson());
-      case "/api/1.0/client/env/00000000-0000-0000-0000-000000000000/target-segments?cluster=1":
+      case "/api/1.0/client/env/00000000-0000-0000-0000-000000000000/target-segments?cluster=1&rules=v2":
         return makeMockJsonResponse(200, makeSegmentsJson());
       case "/api/1.0/stream?cluster=1":
         return makeMockStreamResponse(


### PR DESCRIPTION
FFM-11356 - Add new query parameter to target-segments

**What**
Adds a new query parameter to tell the BE which rule JSON format the SDK is capable of handling locally

**Why**
Caching can be performed on the BE by keying on the URL

**Testing**
Manual + proxy