### PR TITLE
[FFM-11459] - Downgrade OpenAPI plugin to allow broader range of Spri…

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -32,7 +32,9 @@ dependencyResolutionManagement {
             library('harness.ff.sdk', 'io.harness', 'ff-java-server-sdk').versionRef('sdk')
 
             // plugins
-            version('openapi.generator', '5.4.0')
+            // do not upgrade openapi, doing so will break compatibility with customers using SpringBoot 2.5.x
+            // (newer 5.x.x generators use APIs not present in okhttp 3.14.9)
+            version('openapi.generator', '4.3.1')
             version('spotless', '6.23.3')
             version('depsize', '0.2.0')
             version('spotbugs', '6.0.4')

--- a/src/main/java/io/harness/cf/client/connector/HarnessConnector.java
+++ b/src/main/java/io/harness/cf/client/connector/HarnessConnector.java
@@ -98,7 +98,7 @@ public class HarnessConnector implements Connector, AutoCloseable {
   private Response reauthInterceptor(Interceptor.Chain chain) throws IOException {
     final Request request =
         chain.request().newBuilder().addHeader("X-Request-ID", getRequestID()).build();
-    log.debug("403 interceptor check: requesting url {}", request.url().url());
+    log.debug("Checking for 403 in interceptor: requesting url {}", request.url().url());
 
     Response response = chain.proceed(request);
 


### PR DESCRIPTION
[FFM-11459] - Downgrade OpenAPI plugin to allow broader range of SpringBoot compatibility

**What**
Downgrade the OpenAPI plugin to 4.3.1

**Why**
Newer 5.x.x plugins are generating code that use newer okhttp APIs. This makes it difficult for customers using older versions of SpringBoot to downgrade because older okhttp versions don't offer these methods. This causes a missing method exception on startup.

**Testing**
SDK smoke tested against the following SpringBoot releases

2.2.13.RELEASE	3.14.9  14-Jan-21
2.3.12.RELEASE	3.14.9  10-Jun-21
2.4.13 	        3.14.9  18-Nov-21
2.5.12 	        3.14.9  31-Mar-22
2.5.15	        3.14.9  18-May-23
2.6.15	        3.14.9  18-May-23
2.7.18	        4.9.3   23-Nov-23
3.0.13          4.10.0  23-Nov-23
3.1.11          4.10.0  18-Apr-23
3.2.5           4.12.0  23-Nov-23
3.3.0-RC1       4.12.0  19-Apr-24