### PR TITLE
FFM-12087 New configuration options + close related bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,14 +78,14 @@ Add the following Maven dependency in your project's pom.xml file:
 <dependency>
     <groupId>io.harness</groupId>
     <artifactId>ff-java-server-sdk</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
 </dependency>
 ```
 
 #### Gradle
 
 ```
-implementation 'io.harness:ff-java-server-sdk:1.7.0'
+implementation 'io.harness:ff-java-server-sdk:1.8.0'
 ```
 
 ### Code Sample

--- a/examples/src/main/java/io/harness/ff/examples/ConfigExample.java
+++ b/examples/src/main/java/io/harness/ff/examples/ConfigExample.java
@@ -35,6 +35,8 @@ public class ConfigExample {
                                 .configUrl("http://localhost:3000/api/1.0")
                                 .eventUrl("http://localhost:3000/api/1.0")
                                 .maxRequestRetry(20)
+                                .flushAnalyticsOnClose(true)
+                                .flushAnalyticsOnCloseTimeout(30000)
                                 .build());
         client = new CfClient(hc);
         client.waitForInitialization();

--- a/examples/src/main/java/io/harness/ff/examples/ConfigExample.java
+++ b/examples/src/main/java/io/harness/ff/examples/ConfigExample.java
@@ -34,6 +34,7 @@ public class ConfigExample {
                         HarnessConfig.builder()
                                 .configUrl("http://localhost:3000/api/1.0")
                                 .eventUrl("http://localhost:3000/api/1.0")
+                                .maxRequestRetry(20)
                                 .build());
         client = new CfClient(hc);
         client.waitForInitialization();

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,7 +4,7 @@ dependencyResolutionManagement {
     versionCatalogs {
         libs {
             // main sdk version
-            version('sdk', '1.7.0');
+            version('sdk', '1.8.0');
 
             // sdk deps
             version('okhttp3', '4.12.0')

--- a/src/main/java/io/harness/cf/client/api/BaseConfig.java
+++ b/src/main/java/io/harness/cf/client/api/BaseConfig.java
@@ -14,7 +14,7 @@ import lombok.experimental.SuperBuilder;
 @Data
 public class BaseConfig {
   public static final int MIN_FREQUENCY = 60;
-  public static final long DEFAULT_REQUEST_RETRIES = 60;
+  public static final long DEFAULT_REQUEST_RETRIES = 10;
 
   @Builder.Default private final boolean streamEnabled = true;
   @Builder.Default private final int pollIntervalInSeconds = 60;
@@ -56,19 +56,55 @@ public class BaseConfig {
   private final Storage store;
 
   /**
-   * +   * Defines the maximum number of retry attempts for certain types of requests:
-   * +   * authentication, polling, metrics, and reacting to stream events. If a request fails,
-   * +   * the SDK will retry up to this number of times before giving up.
-   * +   * <p>
-   * +   * - Authentication: Used for retrying authentication requests when the server is unreachable.
-   * +   * - Polling: Applies to requests that fetch feature flags and target groups periodically.
-   * +   * - Metrics: Applies to analytics requests for sending metrics data to the server.
-   * +   * - Reacting to Stream Events: Applies to requests triggered by streamed flag or group changes,
-   * +   *   where the SDK needs to fetch updated flag or group data.
-   * +   * <p>
-   * +   * Note: This setting does not apply to streaming requests (either the initial connection or
-   * +   * reconnecting after a disconnection). Streaming requests will always retry indefinitely
-   * +   * (infinite retries).
-   * +   */
-  @Builder.Default long maxRequestRetry = DEFAULT_REQUEST_RETRIES;
+   * Defines the maximum number of retry attempts for certain types of requests:
+   * authentication, polling, metrics, and reacting to stream events. If a request fails,
+   * the SDK will retry up to this number of times before giving up.
+   * <p>
+   * - Authentication: Used for retrying authentication requests when the server is unreachable.
+   * - Polling: Applies to requests that fetch feature flags and target groups periodically.
+   * - Metrics: Applies to analytics requests for sending metrics data to the server.
+   * - Reacting to Stream Events: Applies to requests triggered by streamed flag or group changes,
+   *   where the SDK needs to fetch updated flag or group data.
+   * <p>
+   * <p>
+   * The default value is {@code 10}.
+   * <p>
+   * <b>Note:</b> This setting does not apply to streaming requests (either the initial connection or
+   * reconnecting after a disconnection). Streaming requests will always retry indefinitely
+   * (infinite retries).
+   * <p>
+   * Example usage:
+   * <pre>
+   * {@code
+   * BaseConfig config = BaseConfig.builder()
+   *     .maxRequestRetry(20)
+   *     .build();
+   * }
+   * </pre>
+   */
+  @Builder.Default private final long maxRequestRetry = DEFAULT_REQUEST_RETRIES;
+
+  /**
+   * Indicates whether to flush analytics data when the SDK is closed.
+   * <p>
+   * When set to {@code true}, any remaining analytics data (such as metrics)
+   * will be sent to the server before the SDK is fully closed. If {@code false},
+   * the data will not be flushed, and any unsent analytics data may be lost.
+   * <p>
+   * The default value is {@code false}.
+   * <p>
+   * <b>Note:</b> The flush will attempt to send the data in a single request.
+   * Any failures during this process will not be retried, and the analytics data
+   * may be lost.
+   *
+   * <p>Example usage:
+   * <pre>
+   * {@code
+   * BaseConfig config = BaseConfig.builder()
+   *     .flushAnalyticsOnClose(true)
+   *     .build();
+   * }
+   * </pre>
+   */
+  @Builder.Default private final boolean flushAnalyticsOnClose = false;
 }

--- a/src/main/java/io/harness/cf/client/api/BaseConfig.java
+++ b/src/main/java/io/harness/cf/client/api/BaseConfig.java
@@ -14,6 +14,7 @@ import lombok.experimental.SuperBuilder;
 @Data
 public class BaseConfig {
   public static final int MIN_FREQUENCY = 60;
+  public static final long DEFAULT_REQUEST_RETRIES = 60;
 
   @Builder.Default private final boolean streamEnabled = true;
   @Builder.Default private final int pollIntervalInSeconds = 60;
@@ -53,4 +54,21 @@ public class BaseConfig {
   @Builder.Default private final Cache cache = new CaffeineCache(10000);
 
   private final Storage store;
+
+  /**
+   * +   * Defines the maximum number of retry attempts for certain types of requests:
+   * +   * authentication, polling, metrics, and reacting to stream events. If a request fails,
+   * +   * the SDK will retry up to this number of times before giving up.
+   * +   * <p>
+   * +   * - Authentication: Used for retrying authentication requests when the server is unreachable.
+   * +   * - Polling: Applies to requests that fetch feature flags and target groups periodically.
+   * +   * - Metrics: Applies to analytics requests for sending metrics data to the server.
+   * +   * - Reacting to Stream Events: Applies to requests triggered by streamed flag or group changes,
+   * +   *   where the SDK needs to fetch updated flag or group data.
+   * +   * <p>
+   * +   * Note: This setting does not apply to streaming requests (either the initial connection or
+   * +   * reconnecting after a disconnection). Streaming requests will always retry indefinitely
+   * +   * (infinite retries).
+   * +   */
+  @Builder.Default long maxRequestRetry = DEFAULT_REQUEST_RETRIES;
 }

--- a/src/main/java/io/harness/cf/client/api/BaseConfig.java
+++ b/src/main/java/io/harness/cf/client/api/BaseConfig.java
@@ -83,28 +83,4 @@ public class BaseConfig {
    * </pre>
    */
   @Builder.Default private final long maxRequestRetry = DEFAULT_REQUEST_RETRIES;
-
-  /**
-   * Indicates whether to flush analytics data when the SDK is closed.
-   * <p>
-   * When set to {@code true}, any remaining analytics data (such as metrics)
-   * will be sent to the server before the SDK is fully closed. If {@code false},
-   * the data will not be flushed, and any unsent analytics data may be lost.
-   * <p>
-   * The default value is {@code false}.
-   * <p>
-   * <b>Note:</b> The flush will attempt to send the data in a single request.
-   * Any failures during this process will not be retried, and the analytics data
-   * may be lost.
-   *
-   * <p>Example usage:
-   * <pre>
-   * {@code
-   * BaseConfig config = BaseConfig.builder()
-   *     .flushAnalyticsOnClose(true)
-   *     .build();
-   * }
-   * </pre>
-   */
-  @Builder.Default private final boolean flushAnalyticsOnClose = false;
 }

--- a/src/main/java/io/harness/cf/client/api/InnerClient.java
+++ b/src/main/java/io/harness/cf/client/api/InnerClient.java
@@ -63,6 +63,7 @@ class InnerClient
             .connectionTimeout(options.getConnectionTimeout())
             .readTimeout(options.readTimeout)
             .writeTimeout(options.getWriteTimeout())
+            .maxRequestRetry(options.getMaxRequestRetry())
             .build();
     HarnessConnector harnessConnector = new HarnessConnector(sdkKey, config);
     setUp(harnessConnector, options);

--- a/src/main/java/io/harness/cf/client/api/InnerClient.java
+++ b/src/main/java/io/harness/cf/client/api/InnerClient.java
@@ -87,7 +87,6 @@ class InnerClient
     log.info("Starting SDK client with configuration: {}", this.options);
     this.connector = connector;
     this.connector.setOnUnauthorized(this::onUnauthorized);
-
     // initialization
     repository =
         new StorageRepository(
@@ -96,7 +95,9 @@ class InnerClient
     authService = new AuthService(this.connector, options.getPollIntervalInSeconds(), this);
     pollProcessor =
         new PollingProcessor(this.connector, repository, options.getPollIntervalInSeconds(), this);
-    metricsProcessor = new MetricsProcessor(this.connector, this.options, this);
+    metricsProcessor =
+        new MetricsProcessor(
+            this.connector, this.options, this, connector.getShouldFlushAnalyticsOnClose());
     updateProcessor = new UpdateProcessor(this.connector, this.repository, this);
 
     // start with authentication

--- a/src/main/java/io/harness/cf/client/api/InnerClient.java
+++ b/src/main/java/io/harness/cf/client/api/InnerClient.java
@@ -387,6 +387,12 @@ class InnerClient
 
   public void close() {
     log.info("Closing the client");
+    // Mark the connector as shutting down to stop request retries from taking place. The
+    // connections will eventually
+    // be evicted when the connector is closed, but this ensures that if metrics are flushed when
+    // closed then it
+    // won't attempt to retry if the first request fails.
+    connector.setIsShuttingDown();
     closing = true;
     off();
     authService.close();

--- a/src/main/java/io/harness/cf/client/api/InnerClient.java
+++ b/src/main/java/io/harness/cf/client/api/InnerClient.java
@@ -389,14 +389,14 @@ class InnerClient
   }
 
   public void close() {
-    closing = true;
     log.info("Closing the client");
+    closing = true;
+
     // Mark the connector as shutting down to stop request retries from taking place. The
     // connections will eventually
     // be evicted when the connector is closed, but this ensures that if metrics are flushed when
     // closed then it won't attempt to retry if the first request fails.
     connector.setIsShuttingDown();
-    closing = true;
     off();
     authService.close();
     repository.close();

--- a/src/main/java/io/harness/cf/client/api/InnerClient.java
+++ b/src/main/java/io/harness/cf/client/api/InnerClient.java
@@ -63,7 +63,6 @@ class InnerClient
             .connectionTimeout(options.getConnectionTimeout())
             .readTimeout(options.readTimeout)
             .writeTimeout(options.getWriteTimeout())
-            .maxRequestRetry(options.getMaxRequestRetry())
             .build();
     HarnessConnector harnessConnector = new HarnessConnector(sdkKey, config);
     setUp(harnessConnector, options);

--- a/src/main/java/io/harness/cf/client/api/InnerClient.java
+++ b/src/main/java/io/harness/cf/client/api/InnerClient.java
@@ -393,8 +393,7 @@ class InnerClient
     // Mark the connector as shutting down to stop request retries from taking place. The
     // connections will eventually
     // be evicted when the connector is closed, but this ensures that if metrics are flushed when
-    // closed then it
-    // won't attempt to retry if the first request fails.
+    // closed then it won't attempt to retry if the first request fails.
     connector.setIsShuttingDown();
     closing = true;
     off();

--- a/src/main/java/io/harness/cf/client/api/InnerClient.java
+++ b/src/main/java/io/harness/cf/client/api/InnerClient.java
@@ -228,7 +228,9 @@ class InnerClient
           closing,
           options.getPollIntervalInSeconds());
       log.debug("SSE disconnect detected - asking poller to refresh flags");
-      pollProcessor.retrieveAll();
+      if (!closing) {
+        pollProcessor.retrieveAll();
+      }
     }
   }
 
@@ -386,6 +388,7 @@ class InnerClient
   }
 
   public void close() {
+    closing = true;
     log.info("Closing the client");
     // Mark the connector as shutting down to stop request retries from taking place. The
     // connections will eventually

--- a/src/main/java/io/harness/cf/client/api/MetricsProcessor.java
+++ b/src/main/java/io/harness/cf/client/api/MetricsProcessor.java
@@ -360,8 +360,7 @@ class MetricsProcessor {
   /* package private */
 
   synchronized ScheduledFuture<?> flushQueue() {
-    scheduler.schedule(this::runOneIteration, 0, SECONDS);
-    return null;
+    return scheduler.schedule(this::runOneIteration, 0, SECONDS);
   }
 
   long getMetricsSent() {

--- a/src/main/java/io/harness/cf/client/api/MetricsProcessor.java
+++ b/src/main/java/io/harness/cf/client/api/MetricsProcessor.java
@@ -304,7 +304,7 @@ class MetricsProcessor {
 
   public void stop() {
     if (config.isFlushAnalyticsOnClose()) {
-      flushWithTimeout(10);
+      flushWithTimeout(config.getFlushAnalyticsOnCloseTimeout());
     }
 
     log.debug("Stopping MetricsProcessor");
@@ -335,14 +335,14 @@ class MetricsProcessor {
     return runningTask != null && !runningTask.isCancelled();
   }
 
-  public synchronized void flushWithTimeout(int timeoutInSeconds) {
+  public synchronized void flushWithTimeout(long timeoutInSeconds) {
     log.debug("Flushing metrics with timeout: {} seconds", timeoutInSeconds);
     ScheduledFuture<?> future = null;
     try {
       future = flushQueue();
 
       // Wait for the task to complete or timeout
-      future.get(timeoutInSeconds, SECONDS);
+      future.get(1, SECONDS);
       log.debug("Metrics successfully flushed within the timeout of {} seconds", timeoutInSeconds);
 
     } catch (TimeoutException e) {

--- a/src/main/java/io/harness/cf/client/api/MetricsProcessor.java
+++ b/src/main/java/io/harness/cf/client/api/MetricsProcessor.java
@@ -309,7 +309,7 @@ class MetricsProcessor {
   }
 
   public void stop() {
-    if (shouldFlushMetricsOnClose) {
+    if (shouldFlushMetricsOnClose && config.isAnalyticsEnabled()) {
       flushQueue();
     }
 

--- a/src/main/java/io/harness/cf/client/connector/Connector.java
+++ b/src/main/java/io/harness/cf/client/connector/Connector.java
@@ -30,5 +30,7 @@ public interface Connector {
 
   void close();
 
+  boolean getShouldFlushAnalyticsOnClose();
+
   void setIsShuttingDown();
 }

--- a/src/main/java/io/harness/cf/client/connector/Connector.java
+++ b/src/main/java/io/harness/cf/client/connector/Connector.java
@@ -29,4 +29,6 @@ public interface Connector {
   Service stream(Updater updater) throws ConnectorException;
 
   void close();
+
+  void setIsShuttingDown();
 }

--- a/src/main/java/io/harness/cf/client/connector/EventSource.java
+++ b/src/main/java/io/harness/cf/client/connector/EventSource.java
@@ -154,6 +154,7 @@ public class EventSource implements Callback, AutoCloseable, Service {
   public void close() {
     stop();
     if (this.streamClient != null) {
+      this.streamClient.dispatcher().executorService().shutdown();
       this.streamClient.connectionPool().evictAll();
     }
     log.debug("EventSource closed");

--- a/src/main/java/io/harness/cf/client/connector/EventSource.java
+++ b/src/main/java/io/harness/cf/client/connector/EventSource.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.net.ssl.*;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -37,6 +38,7 @@ public class EventSource implements Callback, AutoCloseable, Service {
   private final Map<String, String> headers;
   private final long sseReadTimeoutMins;
   private final List<X509Certificate> trustedCAs;
+  private final AtomicBoolean isShuttingDown;
 
   static {
     LogUtil.setSystemProps();
@@ -48,7 +50,7 @@ public class EventSource implements Callback, AutoCloseable, Service {
       @NonNull Updater updater,
       long sseReadTimeoutMins)
       throws ConnectorException {
-    this(url, headers, updater, sseReadTimeoutMins, 2_000, null);
+    this(url, headers, updater, sseReadTimeoutMins, 2_000, null, new AtomicBoolean(false));
   }
 
   EventSource(
@@ -57,7 +59,8 @@ public class EventSource implements Callback, AutoCloseable, Service {
       @NonNull Updater updater,
       long sseReadTimeoutMins,
       int retryBackoffDelay,
-      List<X509Certificate> trustedCAs) {
+      List<X509Certificate> trustedCAs,
+      AtomicBoolean isShuttingDown) {
     this.url = url;
     this.headers = headers;
     this.updater = updater;
@@ -65,6 +68,7 @@ public class EventSource implements Callback, AutoCloseable, Service {
     this.retryBackoffDelay = retryBackoffDelay;
     this.trustedCAs = trustedCAs;
     this.loggingInterceptor = new HttpLoggingInterceptor();
+    this.isShuttingDown = isShuttingDown;
   }
 
   protected OkHttpClient makeStreamClient(long sseReadTimeoutMins, List<X509Certificate> trustedCAs)
@@ -83,7 +87,8 @@ public class EventSource implements Callback, AutoCloseable, Service {
       httpClientBuilder.interceptors().remove(loggingInterceptor);
     }
 
-    httpClientBuilder.addInterceptor(new NewRetryInterceptor(retryBackoffDelay, true));
+    httpClientBuilder.addInterceptor(
+        new NewRetryInterceptor(retryBackoffDelay, true, isShuttingDown));
     return httpClientBuilder.build();
   }
 

--- a/src/main/java/io/harness/cf/client/connector/EventSource.java
+++ b/src/main/java/io/harness/cf/client/connector/EventSource.java
@@ -83,7 +83,7 @@ public class EventSource implements Callback, AutoCloseable, Service {
       httpClientBuilder.interceptors().remove(loggingInterceptor);
     }
 
-    httpClientBuilder.addInterceptor(new NewRetryInterceptor(retryBackoffDelay));
+    httpClientBuilder.addInterceptor(new NewRetryInterceptor(retryBackoffDelay, true));
     return httpClientBuilder.build();
   }
 

--- a/src/main/java/io/harness/cf/client/connector/HarnessConfig.java
+++ b/src/main/java/io/harness/cf/client/connector/HarnessConfig.java
@@ -31,6 +31,36 @@ public class HarnessConfig {
   @Builder.Default long sseReadTimeout = 1;
 
   /**
+   * The timeout for flushing analytics on SDK close.
+   * <p>
+   * This option sets the maximum duration, in milliseconds, the SDK will wait for the
+   * analytics data to be flushed after the SDK has been closed. If the flush process takes longer
+   * than this timeout, the request will be canceled, and any remaining data will
+   * not be sent. This ensures that the SDK does not hang indefinitely during shutdown.
+   * <p>
+   * The default value is {@code 30000ms} which is the default read timeout for requests made by the SDK
+   * <p>
+   * <b>Note:</b> This timeout only applies to the flush process that happens when
+   * {@code flushAnalyticsOnClose} is set to {@code true}. It does not affect other
+   * requests made by the SDK during normal operation.
+   *
+   * <p>Example usage:
+   * <pre>
+   * {@code
+   * // Timeout the analytics flush request in 3000ms (3 seconds)
+   * HarnessConfig harnessConfig =
+   *                 HarnessConfig.builder().flushAnalyticsOnCloseTimeout(3000).build();
+   *
+   * // flush analytics on close is enabled via BaseConfig
+   * BaseConfig config = BaseConfig.builder()
+   *     .flushAnalyticsOnClose(true)
+   *     .build();
+   * }
+   * </pre>
+   */
+  @Builder.Default private final long flushAnalyticsOnCloseTimeout = 30000;
+
+  /**
    * list of trusted CAs - for when the given config/event URLs are signed with a private CA. You
    * should include intermediate CAs too to allow the HTTP client to build a full trust chain.
    */

--- a/src/main/java/io/harness/cf/client/connector/HarnessConfig.java
+++ b/src/main/java/io/harness/cf/client/connector/HarnessConfig.java
@@ -52,4 +52,28 @@ public class HarnessConfig {
    * (infinite retries).
    */
   @Builder.Default private long maxRequestRetry = 10;
+
+  /**
+   * Indicates whether to flush analytics data when the SDK is closed.
+   * <p>
+   * When set to {@code true}, any remaining analytics data (such as metrics)
+   * will be sent to the server before the SDK is fully closed. If {@code false},
+   * the data will not be flushed, and any unsent analytics data may be lost.
+   * <p>
+   * The default value is {@code false}.
+   * <p>
+   * <b>Note:</b> The flush will attempt to send the data in a single request.
+   * Any failures during this process will not be retried, and the analytics data
+   * may be lost.
+   *
+   * <p>Example usage:
+   * <pre>
+   * {@code
+   * BaseConfig config = BaseConfig.builder()
+   *     .flushAnalyticsOnClose(true)
+   *     .build();
+   * }
+   * </pre>
+   */
+  @Builder.Default private boolean flushAnalyticsOnClose = false;
 }

--- a/src/main/java/io/harness/cf/client/connector/HarnessConfig.java
+++ b/src/main/java/io/harness/cf/client/connector/HarnessConfig.java
@@ -52,28 +52,4 @@ public class HarnessConfig {
    * (infinite retries).
    */
   @Builder.Default private long maxRequestRetry = 10;
-
-  /**
-   * Indicates whether to flush analytics data when the SDK is closed.
-   * <p>
-   * When set to {@code true}, any remaining analytics data (such as metrics)
-   * will be sent to the server before the SDK is fully closed. If {@code false},
-   * the data will not be flushed, and any unsent analytics data may be lost.
-   * <p>
-   * The default value is {@code false}.
-   * <p>
-   * <b>Note:</b> The flush will attempt to send the data in a single request.
-   * Any failures during this process will not be retried, and the analytics data
-   * may be lost.
-   *
-   * <p>Example usage:
-   * <pre>
-   * {@code
-   * BaseConfig config = BaseConfig.builder()
-   *     .flushAnalyticsOnClose(true)
-   *     .build();
-   * }
-   * </pre>
-   */
-  @Builder.Default private boolean flushAnalyticsOnClose = false;
 }

--- a/src/main/java/io/harness/cf/client/connector/HarnessConfig.java
+++ b/src/main/java/io/harness/cf/client/connector/HarnessConfig.java
@@ -35,4 +35,21 @@ public class HarnessConfig {
    * should include intermediate CAs too to allow the HTTP client to build a full trust chain.
    */
   @Builder.Default List<X509Certificate> tlsTrustedCAs = null;
+
+  /**
+   * Defines the maximum number of retry attempts for certain types of requests:
+   * authentication, polling, metrics, and reacting to stream events. If a request fails,
+   * the SDK will retry up to this number of times before giving up.
+   * <p>
+   * - Authentication: Used for retrying authentication requests when the server is unreachable.
+   * - Polling: Applies to requests that fetch feature flags and target groups periodically.
+   * - Metrics: Applies to analytics requests for sending metrics data to the server.
+   * - Reacting to Stream Events: Applies to requests triggered by streamed flag or group changes,
+   *   where the SDK needs to fetch updated flag or group data.
+   * <p>
+   * Note: This setting does not apply to streaming requests (either the initial connection or
+   * reconnecting after a disconnection). Streaming requests will always retry indefinitely
+   * (infinite retries).
+   */
+  @Builder.Default private long maxRequestRetry = 10;
 }

--- a/src/main/java/io/harness/cf/client/connector/HarnessConfig.java
+++ b/src/main/java/io/harness/cf/client/connector/HarnessConfig.java
@@ -58,7 +58,7 @@ public class HarnessConfig {
    * }
    * </pre>
    */
-  @Builder.Default private final long flushAnalyticsOnCloseTimeout = 30000;
+  @Builder.Default private final int flushAnalyticsOnCloseTimeout = 30000;
 
   /**
    * list of trusted CAs - for when the given config/event URLs are signed with a private CA. You

--- a/src/main/java/io/harness/cf/client/connector/HarnessConfig.java
+++ b/src/main/java/io/harness/cf/client/connector/HarnessConfig.java
@@ -31,36 +31,6 @@ public class HarnessConfig {
   @Builder.Default long sseReadTimeout = 1;
 
   /**
-   * The timeout for flushing analytics on SDK close.
-   * <p>
-   * This option sets the maximum duration, in milliseconds, the SDK will wait for the
-   * analytics data to be flushed after the SDK has been closed. If the flush process takes longer
-   * than this timeout, the request will be canceled, and any remaining data will
-   * not be sent. This ensures that the SDK does not hang indefinitely during shutdown.
-   * <p>
-   * The default value is {@code 30000ms} which is the default read timeout for requests made by the SDK
-   * <p>
-   * <b>Note:</b> This timeout only applies to the flush process that happens when
-   * {@code flushAnalyticsOnClose} is set to {@code true}. It does not affect other
-   * requests made by the SDK during normal operation.
-   *
-   * <p>Example usage:
-   * <pre>
-   * {@code
-   * // Timeout the analytics flush request in 3000ms (3 seconds)
-   * HarnessConfig harnessConfig =
-   *                 HarnessConfig.builder().flushAnalyticsOnCloseTimeout(3000).build();
-   *
-   * // flush analytics on close is enabled via BaseConfig
-   * BaseConfig config = BaseConfig.builder()
-   *     .flushAnalyticsOnClose(true)
-   *     .build();
-   * }
-   * </pre>
-   */
-  @Builder.Default private final int flushAnalyticsOnCloseTimeout = 30000;
-
-  /**
    * list of trusted CAs - for when the given config/event URLs are signed with a private CA. You
    * should include intermediate CAs too to allow the HTTP client to build a full trust chain.
    */
@@ -82,4 +52,56 @@ public class HarnessConfig {
    * (infinite retries).
    */
   @Builder.Default private long maxRequestRetry = 10;
+
+  /**
+   * Indicates whether to flush analytics data when the SDK is closed.
+   * <p>
+   * When set to {@code true}, any remaining analytics data (such as metrics)
+   * will be sent to the server before the SDK is fully closed. If {@code false},
+   * the data will not be flushed, and any unsent analytics data may be lost.
+   * <p>
+   * The default value is {@code false}.
+   * <p>
+   * <b>Note:</b> The flush will attempt to send the data in a single request.
+   * Any failures during this process will not be retried, and the analytics data
+   * may be lost.
+   *
+   * <p>Example usage:
+   * <pre>
+   * {@code
+   * HarnessConfig harnessConfig = HarnessConfig.builder()
+   *     .flushAnalyticsOnClose(true)
+   *     .build();
+   * }
+   * </pre>
+   */
+  @Builder.Default private final boolean flushAnalyticsOnClose = false;
+
+  /**
+   * The timeout for flushing analytics on SDK close.
+   * <p>
+   * This option sets the maximum duration, in milliseconds, the SDK will wait for the
+   * analytics data to be flushed after the SDK has been closed. If the flush process takes longer
+   * than this timeout, the request will be canceled, and any remaining data will
+   * not be sent. This ensures that the SDK does not hang indefinitely during shutdown.
+   * <p>
+   * The default value is {@code 30000ms} which is the default read timeout for requests made by the SDK
+   * <p>
+   * <b>Note:</b> This timeout only applies to the flush process that happens when
+   * {@code flushAnalyticsOnClose} is set to {@code true}. It does not affect other
+   * requests made by the SDK during normal operation.
+   *
+   * <p>Example usage:
+   * <pre>
+   * {@code
+   *
+   * HarnessConfig harnessConfig = HarnessConfig.builder()
+   *     .flushAnalyticsOnClose(true)
+   *      // Timeout the analytics flush request in 3000ms (3 seconds)
+   *     .flushAnalyticsOnCloseTimeout(3000).build();
+   *     .build();
+   * }
+   * </pre>
+   */
+  @Builder.Default private final int flushAnalyticsOnCloseTimeout = 30000;
 }

--- a/src/main/java/io/harness/cf/client/connector/HarnessConnector.java
+++ b/src/main/java/io/harness/cf/client/connector/HarnessConnector.java
@@ -89,7 +89,7 @@ public class HarnessConnector implements Connector, AutoCloseable {
             .getHttpClient()
             .newBuilder()
             .addInterceptor(this::reauthInterceptor)
-            .addInterceptor(new NewRetryInterceptor(3, retryBackOfDelay))
+            .addInterceptor(new NewRetryInterceptor(options.getMaxRequestRetry(), retryBackOfDelay))
             .build());
 
     return apiClient;
@@ -127,7 +127,8 @@ public class HarnessConnector implements Connector, AutoCloseable {
             .getHttpClient()
             .newBuilder()
             .addInterceptor(this::metricsInterceptor)
-            .addInterceptor(new NewRetryInterceptor(3, retryBackoffDelay))
+            .addInterceptor(
+                new NewRetryInterceptor(options.getMaxRequestRetry(), retryBackoffDelay))
             .build());
 
     return apiClient;

--- a/src/main/java/io/harness/cf/client/connector/HarnessConnector.java
+++ b/src/main/java/io/harness/cf/client/connector/HarnessConnector.java
@@ -134,7 +134,7 @@ public class HarnessConnector implements Connector, AutoCloseable {
         apiClient
             .getHttpClient()
             .newBuilder()
-            //            .addInterceptor(this::metricsInterceptor)
+            .addInterceptor(this::metricsInterceptor)
             .addInterceptor(
                 new NewRetryInterceptor(
                     options.getMaxRequestRetry(), retryBackoffDelay, isShuttingDown))
@@ -144,9 +144,6 @@ public class HarnessConnector implements Connector, AutoCloseable {
   }
 
   private Response metricsInterceptor(Interceptor.Chain chain) throws IOException {
-    if (isShuttingDown.get()) {
-      return null;
-    }
     final Request request =
         chain.request().newBuilder().addHeader("X-Request-ID", getRequestID()).build();
     log.debug("metrics interceptor: requesting url {}", request.url().url());

--- a/src/main/java/io/harness/cf/client/connector/HarnessConnector.java
+++ b/src/main/java/io/harness/cf/client/connector/HarnessConnector.java
@@ -100,6 +100,10 @@ public class HarnessConnector implements Connector, AutoCloseable {
   }
 
   private Response reauthInterceptor(Interceptor.Chain chain) throws IOException {
+    if (isShuttingDown.get()) {
+      return null;
+    }
+
     final Request request =
         chain.request().newBuilder().addHeader("X-Request-ID", getRequestID()).build();
     log.debug("Checking for 403 in interceptor: requesting url {}", request.url().url());
@@ -140,6 +144,9 @@ public class HarnessConnector implements Connector, AutoCloseable {
   }
 
   private Response metricsInterceptor(Interceptor.Chain chain) throws IOException {
+    if (isShuttingDown.get()) {
+      return null;
+    }
     final Request request =
         chain.request().newBuilder().addHeader("X-Request-ID", getRequestID()).build();
     log.debug("metrics interceptor: requesting url {}", request.url().url());

--- a/src/main/java/io/harness/cf/client/connector/HarnessConnector.java
+++ b/src/main/java/io/harness/cf/client/connector/HarnessConnector.java
@@ -34,6 +34,7 @@ public class HarnessConnector implements Connector, AutoCloseable {
   private final MetricsApi metricsApi;
   private final String apiKey;
   private final HarnessConfig options;
+
   private final AtomicBoolean isShuttingDown = new AtomicBoolean(false);
 
   private String token;
@@ -471,6 +472,11 @@ public class HarnessConnector implements Connector, AutoCloseable {
 
   public void setIsShuttingDown() {
     this.isShuttingDown.set(true);
+  }
+
+  @Override
+  public boolean getShouldFlushAnalyticsOnClose() {
+    return options.isFlushAnalyticsOnClose();
   }
 
   private static boolean isNullOrEmpty(String string) {

--- a/src/main/java/io/harness/cf/client/connector/HarnessConnector.java
+++ b/src/main/java/io/harness/cf/client/connector/HarnessConnector.java
@@ -134,7 +134,7 @@ public class HarnessConnector implements Connector, AutoCloseable {
         apiClient
             .getHttpClient()
             .newBuilder()
-            .addInterceptor(this::metricsInterceptor)
+            //            .addInterceptor(this::metricsInterceptor)
             .addInterceptor(
                 new NewRetryInterceptor(
                     options.getMaxRequestRetry(), retryBackoffDelay, isShuttingDown))

--- a/src/main/java/io/harness/cf/client/connector/HarnessConnector.java
+++ b/src/main/java/io/harness/cf/client/connector/HarnessConnector.java
@@ -158,9 +158,9 @@ public class HarnessConnector implements Connector, AutoCloseable {
 
       // Apply custom timeouts (e.g., 5 seconds for each timeout type)
       return chain
-          .withConnectTimeout(5, TimeUnit.SECONDS) // Custom connect timeout
-          .withReadTimeout(5, TimeUnit.SECONDS) // Custom read timeout
-          .withWriteTimeout(5, TimeUnit.SECONDS) // Custom write timeout
+          .withConnectTimeout(options.getFlushAnalyticsOnCloseTimeout(), TimeUnit.MILLISECONDS)
+          .withReadTimeout(options.getFlushAnalyticsOnCloseTimeout(), TimeUnit.MILLISECONDS)
+          .withWriteTimeout(options.getFlushAnalyticsOnCloseTimeout(), TimeUnit.MILLISECONDS)
           .proceed(shutdownRequest);
     } else {
       final Request request =

--- a/src/main/java/io/harness/cf/client/connector/HarnessConnector.java
+++ b/src/main/java/io/harness/cf/client/connector/HarnessConnector.java
@@ -445,6 +445,10 @@ public class HarnessConnector implements Connector, AutoCloseable {
     }
   }
 
+  public void setIsShuttingDown() {
+    this.isShuttingDown.set(true);
+  }
+
   private static boolean isNullOrEmpty(String string) {
     return string == null || string.trim().isEmpty();
   }

--- a/src/main/java/io/harness/cf/client/connector/LocalConnector.java
+++ b/src/main/java/io/harness/cf/client/connector/LocalConnector.java
@@ -195,6 +195,9 @@ public class LocalConnector implements Connector, AutoCloseable {
     log.debug("LocalConnector closed");
   }
 
+  @Override
+  public void setIsShuttingDown() {}
+
   private class FileWatcherService implements Service, AutoCloseable {
     private final FileWatcher flagWatcher;
     private final FileWatcher segmentWatcher;

--- a/src/main/java/io/harness/cf/client/connector/LocalConnector.java
+++ b/src/main/java/io/harness/cf/client/connector/LocalConnector.java
@@ -15,7 +15,6 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.NonNull;
@@ -42,7 +41,6 @@ public class LocalConnector implements Connector, AutoCloseable {
   private static final String SEGMENTS = "segments";
   private final String source;
   private final Gson gson = new Gson();
-  private final AtomicBoolean isShuttingDown = new AtomicBoolean(false);
 
   static {
     LogUtil.setSystemProps();
@@ -199,13 +197,12 @@ public class LocalConnector implements Connector, AutoCloseable {
 
   @Override
   public boolean getShouldFlushAnalyticsOnClose() {
-    // TODO - do we want to support flush for local connector? need to pass it in somehow
     return false;
   }
 
   @Override
   public void setIsShuttingDown() {
-    isShuttingDown.set(true);
+    // No need for local connector as no retries used
   }
 
   private class FileWatcherService implements Service, AutoCloseable {

--- a/src/main/java/io/harness/cf/client/connector/LocalConnector.java
+++ b/src/main/java/io/harness/cf/client/connector/LocalConnector.java
@@ -15,6 +15,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.NonNull;
@@ -41,6 +42,7 @@ public class LocalConnector implements Connector, AutoCloseable {
   private static final String SEGMENTS = "segments";
   private final String source;
   private final Gson gson = new Gson();
+  private final AtomicBoolean isShuttingDown = new AtomicBoolean(false);
 
   static {
     LogUtil.setSystemProps();
@@ -196,7 +198,9 @@ public class LocalConnector implements Connector, AutoCloseable {
   }
 
   @Override
-  public void setIsShuttingDown() {}
+  public void setIsShuttingDown() {
+    isShuttingDown.set(true);
+  }
 
   private class FileWatcherService implements Service, AutoCloseable {
     private final FileWatcher flagWatcher;

--- a/src/main/java/io/harness/cf/client/connector/LocalConnector.java
+++ b/src/main/java/io/harness/cf/client/connector/LocalConnector.java
@@ -198,6 +198,12 @@ public class LocalConnector implements Connector, AutoCloseable {
   }
 
   @Override
+  public boolean getShouldFlushAnalyticsOnClose() {
+    // TODO - do we want to support flush for local connector? need to pass it in somehow
+    return false;
+  }
+
+  @Override
   public void setIsShuttingDown() {
     isShuttingDown.set(true);
   }

--- a/src/main/java/io/harness/cf/client/connector/NewRetryInterceptor.java
+++ b/src/main/java/io/harness/cf/client/connector/NewRetryInterceptor.java
@@ -96,7 +96,8 @@ public class NewRetryInterceptor implements Interceptor {
           log.trace("Retry-After header detected: {} seconds", retryAfterHeaderValue);
           backOffDelayMs = retryAfterHeaderValue * 1000L;
         } else {
-          // Else fallback to a randomized exponential backoff with a max delay of 1 minute (60,000ms)
+          // Else fallback to a randomized exponential backoff with a max delay of 1 minute
+          // (60,000ms)
           backOffDelayMs = Math.min(retryBackoffDelay * tryCount, 60000L);
         }
 

--- a/src/main/java/io/harness/cf/client/connector/NewRetryInterceptor.java
+++ b/src/main/java/io/harness/cf/client/connector/NewRetryInterceptor.java
@@ -109,6 +109,16 @@ public class NewRetryInterceptor implements Interceptor {
 
         String retryLimitDisplay = retryForever ? "∞" : String.valueOf(maxTryCount);
         limitReached = !retryForever && tryCount >= maxTryCount;
+
+        if (isShuttingDown.get()) {
+          log.warn(
+              "Request attempt {} to {} was not successful, [{}], SDK is shutting down, no retries will be attempted",
+              tryCount,
+              chain.request().url(),
+              msg);
+          return response; // Exit without further retries
+        }
+
         log.warn(
             "Request attempt {} of {} to {} was not successful, [{}]{}",
             tryCount,

--- a/src/main/java/io/harness/cf/client/connector/NewRetryInterceptor.java
+++ b/src/main/java/io/harness/cf/client/connector/NewRetryInterceptor.java
@@ -60,12 +60,6 @@ public class NewRetryInterceptor implements Interceptor {
     Response response = null;
     String msg = "";
     do {
-
-      //      if (isShuttingDown.get()) {
-      //        log.debug("SDK is shutting down, aborting retry interceptor");
-      //        return response;
-      //      }
-
       try {
         if (response != null) response.close();
 
@@ -102,8 +96,7 @@ public class NewRetryInterceptor implements Interceptor {
           log.trace("Retry-After header detected: {} seconds", retryAfterHeaderValue);
           backOffDelayMs = retryAfterHeaderValue * 1000L;
         } else {
-          // Else fallback to a randomized exponential backoff with a max delay of 1 minute (60,000
-          // ms)
+          // Else fallback to a randomized exponential backoff with a max delay of 1 minute (60,000ms)
           backOffDelayMs = Math.min(retryBackoffDelay * tryCount, 60000L);
         }
 

--- a/src/main/java/io/harness/cf/client/connector/NewRetryInterceptor.java
+++ b/src/main/java/io/harness/cf/client/connector/NewRetryInterceptor.java
@@ -1,5 +1,7 @@
 package io.harness.cf.client.connector;
 
+import static io.harness.cf.client.api.BaseConfig.DEFAULT_REQUEST_RETRIES;
+
 import java.io.IOException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -21,8 +23,8 @@ public class NewRetryInterceptor implements Interceptor {
   private final long retryBackoffDelay;
   private final boolean retryForever;
 
-  // Default to 10 retries if not specified
-  private long maxTryCount = 10;
+  // Use SDK default is not specified
+  private long maxTryCount = DEFAULT_REQUEST_RETRIES;
 
   public NewRetryInterceptor(long retryBackoffDelay) {
     this.retryBackoffDelay = retryBackoffDelay;
@@ -76,9 +78,11 @@ public class NewRetryInterceptor implements Interceptor {
           return response;
         }
       }
+
       if (!successful) {
         int retryAfterHeaderValue = getRetryAfterHeaderInSeconds(response);
         long backOffDelayMs;
+
         if (retryAfterHeaderValue > 0) {
           // Use Retry-After header if detected first
           log.trace("Retry-After header detected: {} seconds", retryAfterHeaderValue);

--- a/src/main/java/io/harness/cf/client/connector/NewRetryInterceptor.java
+++ b/src/main/java/io/harness/cf/client/connector/NewRetryInterceptor.java
@@ -61,10 +61,10 @@ public class NewRetryInterceptor implements Interceptor {
     String msg = "";
     do {
 
-      if (isShuttingDown.get()) {
-        log.debug("SDK is shutting down, aborting retry interceptor");
-        break;
-      }
+      //      if (isShuttingDown.get()) {
+      //        log.debug("SDK is shutting down, aborting retry interceptor");
+      //        return response;
+      //      }
 
       try {
         if (response != null) response.close();

--- a/src/test/java/io/harness/cf/client/api/MetricsProcessorStressTest.java
+++ b/src/test/java/io/harness/cf/client/api/MetricsProcessorStressTest.java
@@ -50,7 +50,8 @@ class MetricsProcessorStressTest {
             BaseConfig.builder()
                 // .globalTargetEnabled(false)
                 .build(),
-            new DummyMetricsCallback());
+            new DummyMetricsCallback(),
+            false);
 
     metricsProcessor.start();
 

--- a/src/test/java/io/harness/cf/client/api/testutils/DummyConnector.java
+++ b/src/test/java/io/harness/cf/client/api/testutils/DummyConnector.java
@@ -79,4 +79,7 @@ public class DummyConnector implements Connector {
 
   @Override
   public void close() {}
+
+  @Override
+  public void setIsShuttingDown() {}
 }

--- a/src/test/java/io/harness/cf/client/api/testutils/DummyConnector.java
+++ b/src/test/java/io/harness/cf/client/api/testutils/DummyConnector.java
@@ -81,5 +81,10 @@ public class DummyConnector implements Connector {
   public void close() {}
 
   @Override
+  public boolean getShouldFlushAnalyticsOnClose() {
+    return false;
+  }
+
+  @Override
   public void setIsShuttingDown() {}
 }

--- a/src/test/java/io/harness/cf/client/connector/EventSourceTest.java
+++ b/src/test/java/io/harness/cf/client/connector/EventSourceTest.java
@@ -120,8 +120,7 @@ class EventSourceTest {
     }
 
     // for this test, connection to the /stream endpoint will never because of an un-retryable
-    // error.
-    // we expect the disconnect handler to be called, connect handler should not be called
+    // error. We expect the disconnect handler to be called, connect handler should not be called
 
     assertEquals(0, updater.getConnectCount().get());
     assertEquals(0, updater.getFailureCount().get());

--- a/src/test/java/io/harness/cf/client/connector/EventSourceTest.java
+++ b/src/test/java/io/harness/cf/client/connector/EventSourceTest.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -84,7 +85,8 @@ class EventSourceTest {
                 updater,
                 1,
                 1,
-                null)) {
+                null,
+                new AtomicBoolean(false))) {
       eventSource.start();
 
       TimeUnit.SECONDS.sleep(15);
@@ -110,7 +112,8 @@ class EventSourceTest {
                 updater,
                 1,
                 1,
-                null)) {
+                null,
+                new AtomicBoolean(false))) {
       eventSource.start();
 
       TimeUnit.SECONDS.sleep(3);


### PR DESCRIPTION
# What
This PR adds two new features, and fixes some bugs around closing the SDK.

## New Features
### Retries
- Adds new `maxRequestRetry` option, defaulting to `10`, which controls the number of retries made for requests to `auth` / `polling` / `metrics` / `fetch flag` and `fetch group` requests

- Changes the stream reconnect limit from `5` attempts to no limit. This was a bug, and to align with our SDKs the stream should always attempt to reconnect (on retryable errors)

- Exponential backoff capped at 1 minute max delay.

### Flush metrics when SDK is closed
- Adds new BaseConfig option `flushAnalyticsOnClose`, defaulting to `disabled`, which will post analytics when the SDK is closed. The default timeout for this request is `30000ms`, before which the SDK will not be fully closed and network resources used by the request will remain open.  
- Adds new HarnessConfig option `flushAnalyticsOnCloseTimeout`, defaulting to `30000ms`, which can help if the user prefers a shorter or longer timeout before all SDK resources are closed. 

## Bug fixes
- The stream executor service remained open when the sdk was closed, causing a memory leak. Now calls `.executorService().shutdown();` 
- Stops making a final poll request when the SDK is closed, which causes noisy error logs as network resources are evicted and the request fails.

# Testing
- Updated unit tests for request retries and metrics flushing
- Extensive manual testing with sample application. 

# Issues

https://github.com/harness/ff-java-server-sdk/issues/201
https://github.com/harness/ff-java-server-sdk/issues/202