### PR TITLE
feat: [FFM-12489]: Adding support for HTTP proxies

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,7 +4,7 @@ dependencyResolutionManagement {
     versionCatalogs {
         libs {
             // main sdk version
-            version('sdk', '1.8.1');
+            version('sdk', '1.8.2');
 
             // sdk deps
             version('okhttp3', '4.12.0')

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,7 +4,7 @@ dependencyResolutionManagement {
     versionCatalogs {
         libs {
             // main sdk version
-            version('sdk', '1.8.2');
+            version('sdk', '1.8.3');
 
             // sdk deps
             version('okhttp3', '4.12.0')

--- a/src/main/java/io/harness/cf/client/connector/DelegatingSocketFactory.java
+++ b/src/main/java/io/harness/cf/client/connector/DelegatingSocketFactory.java
@@ -1,0 +1,45 @@
+package io.harness.cf.client.connector;
+
+import javax.net.SocketFactory;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+
+final class DelegatingSocketFactory extends SocketFactory {
+    private final SocketFactory delegate;
+
+    public DelegatingSocketFactory(SocketFactory delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Socket createSocket() throws IOException {
+        return configureSocket(delegate.createSocket());
+    }
+
+    @Override
+    public Socket createSocket(String host, int port) throws IOException {
+        return configureSocket(delegate.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port, InetAddress localAddress,
+                               int localPort) throws IOException {
+        return configureSocket(delegate.createSocket(host, port, localAddress, localPort));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress host, int port) throws IOException {
+        return configureSocket(delegate.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress host, int port, InetAddress localAddress,
+                               int localPort) throws IOException {
+        return configureSocket(delegate.createSocket(host, port, localAddress, localPort));
+    }
+
+    Socket configureSocket(Socket socket) {
+        return socket;
+    }
+}

--- a/src/main/java/io/harness/cf/client/connector/EventSource.java
+++ b/src/main/java/io/harness/cf/client/connector/EventSource.java
@@ -75,6 +75,8 @@ public class EventSource implements Callback, AutoCloseable, Service {
       throws ConnectorException {
     OkHttpClient.Builder httpClientBuilder =
         new OkHttpClient.Builder()
+            .proxy(ProxyConfig.getProxyConfig())
+            .proxyAuthenticator(ProxyConfig.getProxyAuthentication())
             .eventListener(EventListener.NONE)
             .readTimeout(sseReadTimeoutMins, TimeUnit.MINUTES)
             .retryOnConnectionFailure(true);

--- a/src/main/java/io/harness/cf/client/connector/EventSource.java
+++ b/src/main/java/io/harness/cf/client/connector/EventSource.java
@@ -81,6 +81,8 @@ public class EventSource implements Callback, AutoCloseable, Service {
             .readTimeout(sseReadTimeoutMins, TimeUnit.MINUTES)
             .retryOnConnectionFailure(true);
 
+    ProxyConfig.setSocketFactory(httpClientBuilder);
+
     setupTls(httpClientBuilder, trustedCAs);
 
     if (log.isDebugEnabled()) {

--- a/src/main/java/io/harness/cf/client/connector/EventSource.java
+++ b/src/main/java/io/harness/cf/client/connector/EventSource.java
@@ -81,7 +81,7 @@ public class EventSource implements Callback, AutoCloseable, Service {
             .readTimeout(sseReadTimeoutMins, TimeUnit.MINUTES)
             .retryOnConnectionFailure(true);
 
-    ProxyConfig.setSocketFactory(httpClientBuilder);
+    ProxyConfig.configureTls(httpClientBuilder);
 
     setupTls(httpClientBuilder, trustedCAs);
 

--- a/src/main/java/io/harness/cf/client/connector/HarnessConnector.java
+++ b/src/main/java/io/harness/cf/client/connector/HarnessConnector.java
@@ -21,6 +21,7 @@ import lombok.NonNull;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.Interceptor;
+import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import org.slf4j.MDC;
@@ -87,18 +88,18 @@ public class HarnessConnector implements Connector, AutoCloseable {
 
     setupTls(apiClient);
 
+    final OkHttpClient.Builder builder = apiClient
+      .getHttpClient()
+      .newBuilder();
+
+    ProxyConfig.setSocketFactory(builder);
+
     // if http client response is 403 we need to reauthenticate
-    apiClient.setHttpClient(
-        apiClient
-            .getHttpClient()
-            .newBuilder()
-            .proxy(ProxyConfig.getProxyConfig())
-            .proxyAuthenticator(ProxyConfig.getProxyAuthentication())
-            .addInterceptor(this::reauthInterceptor)
-            .addInterceptor(
-                new NewRetryInterceptor(
-                    options.getMaxRequestRetry(), retryBackOfDelay, isShuttingDown))
-            .build());
+    apiClient.setHttpClient(builder.proxy(ProxyConfig.getProxyConfig())
+      .proxyAuthenticator(ProxyConfig.getProxyAuthentication())
+      .addInterceptor(this::reauthInterceptor)
+      .addInterceptor(new NewRetryInterceptor(options.getMaxRequestRetry(), retryBackOfDelay, isShuttingDown))
+      .build());
 
     return apiClient;
   }

--- a/src/main/java/io/harness/cf/client/connector/HarnessConnector.java
+++ b/src/main/java/io/harness/cf/client/connector/HarnessConnector.java
@@ -92,7 +92,7 @@ public class HarnessConnector implements Connector, AutoCloseable {
       .getHttpClient()
       .newBuilder();
 
-    ProxyConfig.setSocketFactory(builder);
+    ProxyConfig.configureTls(builder);
 
     // if http client response is 403 we need to reauthenticate
     apiClient.setHttpClient(builder.proxy(ProxyConfig.getProxyConfig())

--- a/src/main/java/io/harness/cf/client/connector/HarnessConnector.java
+++ b/src/main/java/io/harness/cf/client/connector/HarnessConnector.java
@@ -92,6 +92,8 @@ public class HarnessConnector implements Connector, AutoCloseable {
         apiClient
             .getHttpClient()
             .newBuilder()
+            .proxy(ProxyConfig.getProxyConfig())
+            .proxyAuthenticator(ProxyConfig.getProxyAuthentication())
             .addInterceptor(this::reauthInterceptor)
             .addInterceptor(
                 new NewRetryInterceptor(

--- a/src/main/java/io/harness/cf/client/connector/ProxyConfig.java
+++ b/src/main/java/io/harness/cf/client/connector/ProxyConfig.java
@@ -1,0 +1,31 @@
+package io.harness.cf.client.connector;
+
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import okhttp3.Authenticator;
+import okhttp3.Credentials;
+
+public class ProxyConfig {
+
+  public static Proxy getProxyConfig() {
+    final String host = System.getProperty("http.proxyHost");
+    final String port = System.getProperty("http.proxyPort");
+    if (host == null || host.isEmpty() || port == null || port.isEmpty()) {
+      return Proxy.NO_PROXY;
+    }
+    return new Proxy(Proxy.Type.HTTP, new InetSocketAddress(host, Integer.parseInt(port)));
+  }
+
+  public static Authenticator getProxyAuthentication() {
+    final String user = System.getProperty("http.proxyUser");
+    final String password = System.getProperty("http.proxyPassword");
+    if (user == null || user.isEmpty() || password == null || password.isEmpty()) {
+      return Authenticator.NONE;
+    }
+
+    return (route, response) -> {
+      final String credential = Credentials.basic(user, password);
+      return response.request().newBuilder().header("Proxy-Authorization", credential).build();
+    };
+  }
+}

--- a/src/main/java/io/harness/cf/client/connector/ProxyConfig.java
+++ b/src/main/java/io/harness/cf/client/connector/ProxyConfig.java
@@ -5,13 +5,16 @@ import java.net.Proxy;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.Authenticator;
 import okhttp3.Credentials;
+import okhttp3.OkHttpClient;
+
+import javax.net.ssl.SSLSocketFactory;
 
 @Slf4j
 public class ProxyConfig {
 
   public static Proxy getProxyConfig() {
-    final String host = System.getProperty("http.proxyHost");
-    final String port = System.getProperty("http.proxyPort");
+    final String host = System.getProperty("https.proxyHost", System.getProperty("http.proxyHost"));
+    final String port = System.getProperty("https.proxyPort", System.getProperty("http.proxyPort"));
     if (host == null || host.isEmpty() || port == null || port.isEmpty()) {
       return Proxy.NO_PROXY;
     }
@@ -47,5 +50,18 @@ public class ProxyConfig {
       return "null";
     }
     return addr.getAddress().getHostAddress() + ":" + addr.getPort();
+  }
+
+  public static void setSocketFactory(OkHttpClient.Builder builder) {
+    if (builder == null) {
+      return;
+    }
+    final String host = System.getProperty("https.proxyHost");
+    final String port = System.getProperty("https.proxyPort");
+    if (host == null || host.isEmpty() || port == null || port.isEmpty()) {
+      return;
+    }
+
+    builder.socketFactory(new DelegatingSocketFactory(SSLSocketFactory.getDefault()));
   }
 }

--- a/src/main/java/io/harness/cf/client/connector/ProxyConfig.java
+++ b/src/main/java/io/harness/cf/client/connector/ProxyConfig.java
@@ -52,7 +52,7 @@ public class ProxyConfig {
     return addr.getAddress().getHostAddress() + ":" + addr.getPort();
   }
 
-  public static void setSocketFactory(OkHttpClient.Builder builder) {
+  public static void configureTls(OkHttpClient.Builder builder) {
     if (builder == null) {
       return;
     }


### PR DESCRIPTION
- Adding (experimental) support for http proxy properties via properties: `http(s).proxyHost`,  `http(s).proxyPort`,  `http.proxyUser` and `http.proxyPassword`. The current implementation passes these directly to okhttp.
 
