### PR TITLE
fix: [FFM-12506]: Avoid logging endpoint errors if SDK is shutting down

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -4,7 +4,7 @@ dependencyResolutionManagement {
     versionCatalogs {
         libs {
             // main sdk version
-            version('sdk', '1.8.1');
+            version('sdk', '1.8.2');
 
             // sdk deps
             version('okhttp3', '4.12.0')

--- a/src/main/java/io/harness/cf/client/api/InnerClient.java
+++ b/src/main/java/io/harness/cf/client/api/InnerClient.java
@@ -209,7 +209,9 @@ class InnerClient
   @Override
   public void onDisconnected(String reason) {
 
-    SdkCodes.warnStreamDisconnected(reason);
+    if (!reason.contains("SDK_SHUTDOWN")) {
+      SdkCodes.warnStreamDisconnected(reason);
+    }
 
     if (!closing && !pollProcessor.isRunning()) {
       log.debug("onDisconnected triggered, starting poller to get latest flags");

--- a/src/main/java/io/harness/cf/client/api/PollingProcessor.java
+++ b/src/main/java/io/harness/cf/client/api/PollingProcessor.java
@@ -71,7 +71,7 @@ class PollingProcessor {
       completableFuture.complete(segments);
     } catch (Throwable e) {
       log.error(
-          "Exception was raised when fetching flags data with the message {}", e.getMessage(), e);
+          "Exception was raised when fetching segments data with the message {}", e.getMessage(), e);
       completableFuture.completeExceptionally(e);
     }
     return completableFuture;
@@ -81,8 +81,7 @@ class PollingProcessor {
     try {
       CompletableFuture.allOf(retrieveFlags(), retrieveSegments()).join();
     } catch (CompletionException | CancellationException ex) {
-      log.warn("retrieveAll failed: {} - {}", ex.getClass().getSimpleName(), ex.getMessage());
-      log.trace("retrieveAll failed", ex);
+      log.warn("retrieveAll failed: {} - {}", ex.getClass().getSimpleName(), ex.getMessage(), ex);
     }
   }
 

--- a/src/main/java/io/harness/cf/client/connector/EventSource.java
+++ b/src/main/java/io/harness/cf/client/connector/EventSource.java
@@ -198,13 +198,14 @@ public class EventSource implements Callback, AutoCloseable, Service {
     } catch (Throwable ex) {
       log.warn("SSE Stream aborted: " + getExceptionMsg(ex));
       log.trace("SSE Stream aborted trace", ex);
-      updater.onDisconnected(getExceptionMsg(ex));
+
+      updater.onDisconnected((isShuttingDown.get() ? "SDK_SHUTDOWN: " : "") + getExceptionMsg(ex));
     }
   }
 
   private String getExceptionMsg(Throwable ex) {
     return (ex.getMessage() == null || "null".equals(ex.getMessage()))
-        ? ex.getClass().getSimpleName()
+        ? ex.getClass().getCanonicalName()
         : ex.getMessage();
   }
 

--- a/src/main/java/io/harness/cf/client/connector/NewRetryInterceptor.java
+++ b/src/main/java/io/harness/cf/client/connector/NewRetryInterceptor.java
@@ -105,7 +105,7 @@ public class NewRetryInterceptor implements Interceptor {
         limitReached = !retryForever && tryCount >= maxTryCount;
 
         if (isShuttingDown.get()) {
-          log.warn(
+          log.trace(
               "Request attempt {} to {} was not successful, [{}], SDK is shutting down, no retries will be attempted",
               tryCount,
               chain.request().url(),
@@ -147,6 +147,7 @@ public class NewRetryInterceptor implements Interceptor {
     try {
       seconds = Integer.parseInt(retryAfterValue);
     } catch (NumberFormatException ignored) {
+      log.trace("Unable to parse Retry-After header as integer: {}", retryAfterValue);
     }
 
     if (seconds <= 0) {
@@ -156,6 +157,7 @@ public class NewRetryInterceptor implements Interceptor {
           seconds = (int) Duration.between(Instant.now(), then.toInstant()).getSeconds();
         }
       } catch (ParseException ignored) {
+        log.warn("Unable to parse  Retry-After header value: `{}` as integer or date", retryAfterValue);
       }
     }
 


### PR DESCRIPTION
Release 1.8.0 inadvertently increased the noise in the logs when the SDK is repeatedly shutdown. With that change, we now check if a shutdown is in progress and if so, it aborts any inflight requests with a generic reset/cancel error. This reset/cancel request inadvertently gets logged which causes misleading endpoint logs. This changes removes that noise.

- Avoid logging disconnect errors on shutdown
- Log additional stack traces for diagnostics
- Fixed polling log to make it more unique
