### PR TITLE
fix: [FFM-12578]: Fixes various CVEs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,15 @@ allprojects {
         sourceCompatibility = JavaVersion.VERSION_1_8
     }
 
+    configurations.configureEach {
+        resolutionStrategy {
+            // version overrides for CVE fixes
+            force 'org.apache.commons:commons-lang3:3.18.0' // CVE-2025-48924
+            force "ch.qos.logback:logback-classic:1.3.15" // CVE-2024-12798, CVE-2024-12801
+            force 'com.google.code.gson:gson:2.13.1' // CVE-2025-53864
+        }
+    }
+
     apply plugin: 'java-library'
     apply plugin: 'org.owasp.dependencycheck'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-rc-3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -40,8 +40,8 @@ dependencyResolutionManagement {
             version('openapi.generator', '4.3.1')
             version('spotless', '7.1.0')
             version('depsize', '0.2.0')
-            version('spotbugs', '6.1.5')
-            version('depcheck', '9.0.7')
+            version('spotbugs', '6.2.3')
+            version('depcheck', '12.1.3')
             version('maven.publish', '0.33.0')
         }
     }


### PR DESCRIPTION

Update various dependencies to remove the following CVEs

```
commons-lang3-3.14.0.jar (pkg:maven/org.apache.commons/commons-lang3@3.14.0, cpe:2.3:a:apache:commons_lang:3.14.0:*:*:*:*:*:*:*) : CVE-2025-48924

gson-2.10.jar (pkg:maven/com.google.code.gson/gson@2.10, cpe:2.3:a:google:gson:2.10:*:*:*:*:*:*:*) : CVE-2025-53864

gson-2.11.0.jar (pkg:maven/com.google.code.gson/gson@2.11.0, cpe:2.3:a:google:gson:2.11.0:*:*:*:*:*:*:*) : CVE-2025-53864

logback-core-1.3.14.jar (pkg:maven/ch.qos.logback/logback-core@1.3.14, cpe:2.3:a:qos:logback:1.3.14:*:*:*:*:*:*:*) : CVE-2024-12798, CVE-2024-12801

```